### PR TITLE
feat(hms): add Hive partition pruning and predicate-aware table provider building

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,27 @@
+## Project Description
+DobbyDB is a datafusion based query engine. It focuses on lakehouse query.
+
+## Supported Table Format
+* Iceberg (parquet)
+* Delta Lake (parquet)
+* Hive (textfile, parquet)
+
+## Supported Metastore
+* HMS
+* Glue
+
+## Commit Requirements
+Format check:
+```bash
+cargo fmt --all -- --check
+```
+
+Clippy check:
+```bash
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+Pass tests:
+```bash
+cargo test --all-targets --all-features --verbose
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ DobbyDB is a datafusion based query engine. It focuses on lakehouse query.
 * Glue
 
 ## Commit Requirements
+Project's code comments, pull request must use English.
+
 Format check:
 ```bash
 cargo fmt --all -- --check

--- a/src/catalog/src/glue_catalog.rs
+++ b/src/catalog/src/glue_catalog.rs
@@ -1,6 +1,8 @@
 use crate::catalog::CatalogConfig;
 use crate::storage::StorageCredential;
-use crate::table_format::table_provider_factory::{TableProviderBuilder, split_table_name};
+use crate::table_format::table_provider_factory::{
+    TableProviderBuilder, deduce_table_format, split_table_name,
+};
 use async_trait::async_trait;
 use aws_config::Region;
 use aws_sdk_glue::Client;
@@ -164,9 +166,12 @@ impl SchemaProvider for GlueSchema {
             }
         };
 
+        let table_format = deduce_table_format(&glue_table_properties)?;
+
         let table_provider_builder = TableProviderBuilder::new(
             table_reference,
             glue_table_properties,
+            table_format,
             CatalogConfig::GLUE(self.config.deref().clone()),
         );
 

--- a/src/catalog/src/hms_catalog.rs
+++ b/src/catalog/src/hms_catalog.rs
@@ -3,7 +3,9 @@ use crate::storage::StorageCredential;
 use crate::table_format::TableFormat;
 use crate::table_format::hive::hive_partition::HivePartition;
 use crate::table_format::hive::hive_storage_info::HiveStorageInfo;
-use crate::table_format::table_provider_factory::{TableProviderBuilder, split_table_name};
+use crate::table_format::table_provider_factory::{
+    TableProviderBuilder, deduce_table_format, split_table_name,
+};
 use async_trait::async_trait;
 use datafusion::catalog::{CatalogProvider, SchemaProvider, TableProvider};
 use datafusion::common::Result;
@@ -175,18 +177,9 @@ impl SchemaProvider for HMSSchema {
             }
         }
 
-        let mut table_provider_builder = TableProviderBuilder::new(
-            table_reference,
-            hms_table_properties,
-            CatalogConfig::HMS(self.config.deref().clone()),
-        );
-        table_provider_builder = table_provider_builder
-            .with_table_metadata_table_name(metadata_table_name.map(|t| t.to_string()));
-
-        if table_provider_builder.deduce_table_format()? == TableFormat::Hive {
-            // if it's hive format, provide more
+        let table_format = deduce_table_format(&hms_table_properties)?;
+        let (hive_storage_info, hive_partitions) = if table_format == TableFormat::Hive {
             let hive_storage_info = HiveStorageInfo::try_new_from_hms_table(&hms_table)?;
-
             let hive_partitions = if !hive_storage_info
                 .table_schema
                 .table_partition_cols()
@@ -208,120 +201,23 @@ impl SchemaProvider for HMSSchema {
             } else {
                 vec![]
             };
+            (Some(hive_storage_info), Some(hive_partitions))
+        } else {
+            (None, None)
+        };
 
-            table_provider_builder =
-                table_provider_builder.with_hive_storage_info(hive_storage_info);
-            table_provider_builder = table_provider_builder.with_hive_partitions(hive_partitions);
-        }
-
+        let table_provider_builder = TableProviderBuilder::new(
+            table_reference,
+            hms_table_properties,
+            table_format,
+            CatalogConfig::HMS(self.config.deref().clone()),
+        );
+        let table_provider_builder = table_provider_builder
+            .with_table_metadata_table_name(metadata_table_name.map(|t| t.to_string()));
+        let table_provider_builder =
+            table_provider_builder.with_hive_storage_info(hive_storage_info);
+        let table_provider_builder = table_provider_builder.with_hive_partitions(hive_partitions);
         Ok(Some(table_provider_builder.build().await?))
-
-        // let is_iceberg = hms_table_properties.contains_key("metadata_location");
-        // let is_delta = hms_table_properties
-        //     .get("spark.sql.sources.provider")
-        //     .map(|s| s.as_str())
-        //     == Some("DELTA");
-        //
-        // if !is_iceberg && !is_delta {
-        //     if let Some(sd) = &hms_table.sd {
-        //         if let Some(input_format) = &sd.input_format {
-        //             match HiveTableProviderFactory::detect_input_format(input_format.as_str()) {
-        //                 Ok(fmt) => {
-        //                     let location = sd
-        //                         .location
-        //                         .as_ref()
-        //                         .ok_or_else(|| {
-        //                             DataFusionError::Internal(
-        //                                 "hive table sd is missing location".to_string(),
-        //                             )
-        //                         })?
-        //                         .to_string();
-        //
-        //                     let data_cols: Vec<(String, String)> = sd
-        //                         .cols
-        //                         .as_ref()
-        //                         .map(|cols| {
-        //                             cols.iter()
-        //                                 .filter_map(|f| {
-        //                                     let name = f.name.as_ref()?.to_string();
-        //                                     let ty = f.r#type.as_ref()?.to_string();
-        //                                     Some((name, ty))
-        //                                 })
-        //                                 .collect()
-        //                         })
-        //                         .unwrap_or_default();
-        //
-        //                     let partition_cols: Vec<(String, String)> = hms_table
-        //                         .partition_keys
-        //                         .as_ref()
-        //                         .map(|keys| {
-        //                             keys.iter()
-        //                                 .filter_map(|f| {
-        //                                     let name = f.name.as_ref()?.to_string();
-        //                                     let ty = f.r#type.as_ref()?.to_string();
-        //                                     Some((name, ty))
-        //                                 })
-        //                                 .collect()
-        //                         })
-        //                         .unwrap_or_default();
-        //
-        //                     let serde_properties: HashMap<String, String> = sd
-        //                         .serde_info
-        //                         .as_ref()
-        //                         .and_then(|s| s.parameters.as_ref())
-        //                         .map(|p| {
-        //                             p.iter()
-        //                                 .map(|(k, v)| (k.to_string(), v.to_string()))
-        //                                 .collect()
-        //                         })
-        //                         .unwrap_or_default();
-        //
-        //                     let storage_credential = self.config.storage_credential.clone();
-        //
-        //                     let hive_info = HiveStorageInfo {
-        //                         location,
-        //                         input_format: fmt,
-        //                         data_cols,
-        //                         partition_cols: partition_cols.clone(),
-        //                         serde_properties,
-        //                         storage_credential,
-        //                     };
-        //
-        //                     let hms_partitions = if !partition_cols.is_empty() {
-        //                         hms_client
-        //                             .get_partitions(
-        //                                 self.schema_name.clone().into(),
-        //                                 table_name.to_string().into(),
-        //                                 i16::MAX,
-        //                             )
-        //                             .await
-        //                             .map(from_thrift_exception)
-        //                             .map_err(|e| DataFusionError::External(e.into()))??
-        //                     } else {
-        //                         vec![]
-        //                     };
-        //
-        //                     let table_provider =
-        //                         HiveTableProviderFactory::try_create_table_provider(
-        //                             hive_info,
-        //                             hms_partitions,
-        //                         )
-        //                         .await?;
-        //                     return Ok(Some(table_provider));
-        //                 }
-        //                 Err(e) => return Err(e),
-        //             }
-        //         }
-        //     }
-        // }
-        //
-        // let table_provider = TableProviderFactory::try_new_table_provider(
-        //     &table_reference,
-        //     metadata_table_name,
-        //     &hms_table_properties,
-        //     CatalogConfig::HMS(self.config.deref().clone()),
-        // )
-        // .await?;
     }
 
     fn table_exist(&self, name: &str) -> bool {

--- a/src/catalog/src/table_format.rs
+++ b/src/catalog/src/table_format.rs
@@ -3,7 +3,7 @@ pub mod hive;
 pub mod iceberg;
 pub mod table_provider_factory;
 
-#[derive(PartialEq)]
+#[derive(Debug, PartialEq)]
 pub enum TableFormat {
     Iceberg,
     Delta,

--- a/src/catalog/src/table_format/hive/hive_table_provider.rs
+++ b/src/catalog/src/table_format/hive/hive_table_provider.rs
@@ -345,7 +345,9 @@ fn prune_partitions(
     state: &dyn Session,
 ) -> Result<Vec<usize>> {
     if partition_fields.is_empty() {
-        return Err(DataFusionError::Internal("partition fields is empty".to_string()));
+        return Err(DataFusionError::Internal(
+            "partition fields is empty".to_string(),
+        ));
     }
     if filters.is_empty() {
         return Ok((0..partitions.len()).collect());
@@ -402,7 +404,9 @@ fn prune_partitions(
 
     let mut filter_result: Option<BooleanArray> = None;
     for filter in compiled_filters {
-        let result_array = filter.evaluate(&batch)?.to_array_of_size(batch.num_rows())?;
+        let result_array = filter
+            .evaluate(&batch)?
+            .to_array_of_size(batch.num_rows())?;
         let bool_array = result_array
             .as_any()
             .downcast_ref::<BooleanArray>()
@@ -433,10 +437,15 @@ fn prune_partitions(
 
 #[allow(unused)]
 fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Result<ArrayRef> {
+    let normalized_values: Vec<Option<&str>> = values
+        .iter()
+        .map(|value| normalize_partition_value(*value))
+        .collect();
+
     match data_type {
         DataType::Int8 => {
             let arr = Int8Array::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(|s| s.parse::<i8>().ok()))
                     .collect::<Vec<_>>(),
@@ -445,7 +454,7 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
         }
         DataType::Int16 => {
             let arr = Int16Array::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(|s| s.parse::<i16>().ok()))
                     .collect::<Vec<_>>(),
@@ -454,7 +463,7 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
         }
         DataType::Int32 => {
             let arr = Int32Array::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(|s| s.parse::<i32>().ok()))
                     .collect::<Vec<_>>(),
@@ -463,7 +472,7 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
         }
         DataType::Int64 => {
             let arr = Int64Array::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(|s| s.parse::<i64>().ok()))
                     .collect::<Vec<_>>(),
@@ -472,7 +481,7 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
         }
         DataType::Float32 => {
             let arr = Float32Array::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(|s| s.parse::<f32>().ok()))
                     .collect::<Vec<_>>(),
@@ -481,7 +490,7 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
         }
         DataType::Float64 => {
             let arr = Float64Array::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(|s| s.parse::<f64>().ok()))
                     .collect::<Vec<_>>(),
@@ -490,7 +499,7 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
         }
         DataType::Boolean => {
             let arr = BooleanArray::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(|s| s.parse::<bool>().ok()))
                     .collect::<Vec<_>>(),
@@ -499,7 +508,7 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
         }
         DataType::Date32 => {
             let arr = Date32Array::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(parse_date_to_days))
                     .collect::<Vec<_>>(),
@@ -508,7 +517,7 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
         }
         DataType::Timestamp(TimeUnit::Microsecond, _) => {
             let arr = TimestampMicrosecondArray::from(
-                values
+                normalized_values
                     .iter()
                     .map(|v| v.and_then(parse_timestamp_micros))
                     .collect::<Vec<_>>(),
@@ -516,9 +525,16 @@ fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Resul
             Ok(Arc::new(arr) as ArrayRef)
         }
         _ => {
-            let arr = StringArray::from(values.to_vec());
+            let arr = StringArray::from(normalized_values);
             Ok(Arc::new(arr) as ArrayRef)
         }
+    }
+}
+
+fn normalize_partition_value(value: Option<&str>) -> Option<&str> {
+    match value {
+        Some("__HIVE_DEFAULT_PARTITION__") | Some("") => None,
+        _ => value,
     }
 }
 
@@ -697,7 +713,7 @@ mod tests {
     use super::*;
     use datafusion::arrow::datatypes::Field;
     use datafusion::logical_expr::expr::InList;
-    use datafusion::logical_expr::{Operator, binary_expr, col, lit};
+    use datafusion::logical_expr::{Expr, Operator, binary_expr, col, lit};
     use datafusion::prelude::SessionContext;
 
     #[test]
@@ -723,9 +739,8 @@ mod tests {
             "hive/tpch_hive.db/textfile_partition_table/p=1"
         );
     }
-
-    #[tokio::test]
-    async fn test_prune_partitions_eq() {
+    #[test]
+    fn test_prune_partitions_eq() {
         let state = SessionContext::new();
         let partition_fields = partition_fields();
         let partitions = sample_partitions();
@@ -738,11 +753,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(surviving, vec![1]);
+        assert_eq!(surviving, vec![1, 5]);
     }
 
-    #[tokio::test]
-    async fn test_prune_partitions_in_list_and_gt() {
+    #[test]
+    fn test_prune_partitions_in_list_and_gt() {
         let state = SessionContext::new();
         let partition_fields = partition_fields();
         let partitions = sample_partitions();
@@ -765,8 +780,28 @@ mod tests {
         assert_eq!(surviving, vec![2]);
     }
 
-    #[tokio::test]
-    async fn test_prune_partitions_ignores_mixed_data_filters() {
+    #[test]
+    fn test_prune_partitions_eq_on_multiple_partition_columns() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[
+                binary_expr(col("dt"), Operator::Eq, lit("2012-01-03")),
+                binary_expr(col("bucket"), Operator::Eq, lit(2_i32)),
+            ],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![1]);
+    }
+
+    #[test]
+    fn test_prune_partitions_ignores_mixed_data_filters() {
         let state = SessionContext::new();
         let partition_fields = partition_fields();
         let partitions = sample_partitions();
@@ -782,11 +817,11 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(surviving, vec![1]);
+        assert_eq!(surviving, vec![1, 5]);
     }
 
-    #[tokio::test]
-    async fn test_prune_partitions_without_partition_filter_keeps_all() {
+    #[test]
+    fn test_prune_partitions_without_partition_filter_keeps_all() {
         let state = SessionContext::new();
         let partition_fields = partition_fields();
         let partitions = sample_partitions();
@@ -799,30 +834,14 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(surviving, vec![0, 1, 2]);
+        assert_eq!(surviving, vec![0, 1, 2, 3, 4, 5]);
     }
 
-    #[tokio::test]
-    async fn test_prune_partitions_null_partition_does_not_match() {
+    #[test]
+    fn test_prune_partitions_null_partition_does_not_match() {
         let state = SessionContext::new();
         let partition_fields = partition_fields();
-        let partitions = vec![
-            HivePartition {
-                location:
-                    "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=__HIVE_DEFAULT_PARTITION__"
-                        .to_string(),
-                partition_values: vec!["__HIVE_DEFAULT_PARTITION__".to_string()],
-            },
-            HivePartition {
-                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=".to_string(),
-                partition_values: vec!["".to_string()],
-            },
-            HivePartition {
-                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-03"
-                    .to_string(),
-                partition_values: vec!["2012-01-03".to_string()],
-            },
-        ];
+        let partitions = sample_partitions();
 
         let surviving = prune_partitions(
             &partitions,
@@ -832,29 +851,146 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(surviving, vec![2]);
+        assert_eq!(surviving, vec![1, 5]);
+    }
+    #[test]
+    fn test_prune_partitions_is_null_matches_null_partitions() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[Expr::IsNull(Box::new(col("dt")))],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![3, 4]);
+    }
+
+    #[test]
+    fn test_prune_partitions_bucket_is_not_null_matches_non_null_partitions() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[Expr::IsNotNull(Box::new(col("bucket")))],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_prune_partitions_dt_eq_and_bucket_is_null_matches_null_bucket_partition() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[
+                binary_expr(col("dt"), Operator::Eq, lit("2012-01-03")),
+                Expr::IsNull(Box::new(col("bucket"))),
+            ],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![5]);
+    }
+
+    #[test]
+
+    fn test_prune_partitions_dt_is_null_and_bucket_eq_matches_intersection() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[
+                Expr::IsNull(Box::new(col("dt"))),
+                binary_expr(col("bucket"), Operator::Eq, lit(2_i32)),
+            ],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![3]);
+    }
+
+    #[test]
+    fn test_prune_partitions_is_null_and_eq_matches_nothing() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[
+                Expr::IsNull(Box::new(col("dt"))),
+                binary_expr(col("dt"), Operator::Eq, lit("2012-01-03")),
+            ],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, Vec::<usize>::new());
     }
 
     fn partition_fields() -> Vec<Arc<Field>> {
-        vec![Arc::new(Field::new("dt", DataType::Utf8, true))]
+        vec![
+            Arc::new(Field::new("dt", DataType::Utf8, true)),
+            Arc::new(Field::new("bucket", DataType::Int32, true)),
+        ]
     }
 
     fn sample_partitions() -> Vec<HivePartition> {
         vec![
             HivePartition {
-                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-01"
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-01/bucket=1"
                     .to_string(),
-                partition_values: vec!["2012-01-01".to_string()],
+                partition_values: vec!["2012-01-01".to_string(), "1".to_string()],
             },
             HivePartition {
-                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-03"
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-03/bucket=2"
                     .to_string(),
-                partition_values: vec!["2012-01-03".to_string()],
+                partition_values: vec!["2012-01-03".to_string(), "2".to_string()],
             },
             HivePartition {
-                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-04"
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-04/bucket=3"
                     .to_string(),
-                partition_values: vec!["2012-01-04".to_string()],
+                partition_values: vec!["2012-01-04".to_string(), "3".to_string()],
+            },
+            HivePartition {
+                location:
+                    "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=__HIVE_DEFAULT_PARTITION__/bucket=2"
+                        .to_string(),
+                partition_values: vec!["__HIVE_DEFAULT_PARTITION__".to_string(), "2".to_string()],
+            },
+            HivePartition {
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=/bucket=1"
+                    .to_string(),
+                partition_values: vec!["".to_string(), "1".to_string()],
+            },
+            HivePartition {
+                location:
+                    "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-03/bucket=__HIVE_DEFAULT_PARTITION__"
+                    .to_string(),
+                partition_values: vec![
+                    "2012-01-03".to_string(),
+                    "__HIVE_DEFAULT_PARTITION__".to_string(),
+                ],
             },
         ]
     }

--- a/src/catalog/src/table_format/hive/hive_table_provider.rs
+++ b/src/catalog/src/table_format/hive/hive_table_provider.rs
@@ -435,7 +435,6 @@ fn prune_partitions(
     Ok(surviving)
 }
 
-#[allow(unused)]
 fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Result<ArrayRef> {
     let normalized_values: Vec<Option<&str>> = values
         .iter()

--- a/src/catalog/src/table_format/hive/hive_table_provider.rs
+++ b/src/catalog/src/table_format/hive/hive_table_provider.rs
@@ -4,10 +4,12 @@ use crate::table_format::hive::hive_partition::HivePartition;
 use crate::table_format::hive::hive_storage_info::HiveInputFormat;
 use async_trait::async_trait;
 use datafusion::arrow::array::{
-    ArrayRef, BooleanArray, Date32Array, Float32Array, Float64Array, Int8Array, Int16Array,
+    Array, ArrayRef, BooleanArray, Date32Array, Float32Array, Float64Array, Int8Array, Int16Array,
     Int32Array, Int64Array, StringArray, TimestampMicrosecondArray,
 };
-use datafusion::arrow::datatypes::{DataType, SchemaRef, TimeUnit};
+use datafusion::arrow::compute;
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::catalog::memory::DataSourceExec;
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::config::CsvOptions;
@@ -56,64 +58,6 @@ impl HiveTableProvider {
     }
 }
 
-// impl HiveTableProvider {
-//     pub fn try_new(info: HiveStorageInfo, hms_partitions: Vec<Partition>) -> Result<Self> {
-//         let partition_col_name_set: HashSet<String> = info
-//             .partition_cols
-//             .iter()
-//             .map(|(name, _)| name.to_ascii_lowercase())
-//             .collect();
-//
-//         let data_fields: Vec<Field> = info
-//             .data_cols
-//             .iter()
-//             .filter(|(name, _)| !partition_col_name_set.contains(&name.to_ascii_lowercase()))
-//             .map(|(name, hive_type)| {
-//                 let dt = hive_type_to_arrow(hive_type)?;
-//                 Ok(Field::new(name, dt, true))
-//             })
-//             .collect::<Result<Vec<_>>>()?;
-//
-//         let partition_fields: Vec<Field> = info
-//             .partition_cols
-//             .iter()
-//             .map(|(name, hive_type)| {
-//                 let dt = hive_type_to_arrow(hive_type)?;
-//                 Ok(Field::new(name, dt, true))
-//             })
-//             .collect::<Result<Vec<_>>>()?;
-//
-//         let data_schema = Arc::new(Schema::new(data_fields));
-//
-//         let mut all_fields = data_schema.fields().to_vec();
-//         all_fields.extend(partition_fields.iter().map(|f| Arc::new(f.clone())));
-//         let full_schema = Arc::new(Schema::new(all_fields));
-//
-//         let partition_col_fields: Vec<FieldRef> =
-//             partition_fields.iter().map(|f| Arc::new(f.clone())).collect();
-//
-//         let partitions = hms_partitions
-//             .into_iter()
-//             .filter_map(|p| {
-//                 let location = p.sd?.location?.to_string();
-//                 let values = p.values?.iter().map(|v| v.to_string()).collect();
-//                 Some(HivePartitionInfo { location, values })
-//             })
-//             .collect();
-//
-//         Ok(Self {
-//             schema: full_schema,
-//             data_schema,
-//             input_format: info.input_format,
-//             location: info.location,
-//             partitions,
-//             partition_col_fields,
-//             serde_properties: info.serde_properties,
-//             storage_credential: info.storage_credential,
-//         })
-//     }
-// }
-
 #[async_trait]
 impl TableProvider for HiveTableProvider {
     fn as_any(&self) -> &dyn Any {
@@ -153,17 +97,20 @@ impl TableProvider for HiveTableProvider {
                 .map(|file_object_meta| PartitionedFile::from(file_object_meta.clone()))
                 .collect()
         } else {
+            let surviving_partition_indices = prune_partitions(
+                &self.partitions,
+                self.hive_storage_info.table_schema.table_partition_cols(),
+                filters,
+                state,
+            )?;
             let mut result: Vec<PartitionedFile> = Vec::new();
-            for partition in &self.partitions {
+            for partition_idx in surviving_partition_indices {
+                let partition = &self.partitions[partition_idx];
                 let file_object_metas = list_files(&object_store, &partition.location).await?;
-                let partition_values: Vec<ScalarValue> = self
-                    .hive_storage_info
-                    .table_schema
-                    .table_partition_cols()
-                    .iter()
-                    .zip(partition.partition_values.iter())
-                    .map(|(field, val)| parse_partition_value(val, field.data_type()))
-                    .collect::<Result<Vec<_>>>()?;
+                let partition_values = build_partition_values(
+                    self.hive_storage_info.table_schema.table_partition_cols(),
+                    partition,
+                )?;
                 result.extend(file_object_metas.iter().map(|file_object_meta| {
                     let mut partition_field = PartitionedFile::from(file_object_meta.clone());
                     partition_field.partition_values = partition_values.clone();
@@ -172,65 +119,6 @@ impl TableProvider for HiveTableProvider {
             }
             result
         };
-
-        // let surviving_partition_indices = if self.partitions.is_empty() {
-        //     vec![]
-        // } else {
-        //     prune_partitions(
-        //         &self.partitions,
-        //         &self.partition_col_fields,
-        //         filters,
-        //         state,
-        //     )?
-        // };
-        //
-        // let (path_schema, path_host) = parse_location_schema_host(&self.location)?;
-        // let store_url = ObjectStoreUrl::parse(format!("{}://{}", path_schema, path_host))?;
-        // let object_store = state.runtime_env().object_store(&store_url)?;
-        //
-        // let mut all_files: Vec<PartitionedFile> = Vec::new();
-
-        // if self.partitions.is_empty() {
-        //     let files = list_files(
-        //         &object_store,
-        //         &self.location,
-        //         &path_schema,
-        //         &path_host,
-        //     )
-        //     .await?;
-        //     all_files.extend(files.into_iter().map(|(path, size)| {
-        //         PartitionedFile::new(path, size)
-        //     }));
-        // } else {
-        //     for idx in surviving_partition_indices {
-        //         let partition = &self.partitions[idx];
-        //         let files = list_files(
-        //             &object_store,
-        //             &partition.location,
-        //             &path_schema,
-        //             &path_host,
-        //         )
-        //         .await?;
-        //
-        //         let partition_values: Vec<datafusion::scalar::ScalarValue> = self
-        //             .partition_col_fields
-        //             .iter()
-        //             .zip(partition.values.iter())
-        //             .map(|(field, val)| parse_partition_value(val, field.data_type()))
-        //             .collect::<Result<Vec<_>>>()?;
-        //
-        //         for (path, size) in files {
-        //             let mut pf = PartitionedFile::new(path, size);
-        //             pf.partition_values = partition_values.clone();
-        //             all_files.push(pf);
-        //         }
-        //     }
-        // }
-        //
-        // let table_schema = TableSchema::new(
-        //     self.data_schema.clone(),
-        //     self.partition_col_fields.clone(),
-        // );
 
         let file_group = FileGroup::new(scan_file_list);
 
@@ -301,6 +189,17 @@ fn build_csv_exec(
     }
     let config = builder.build();
     Ok(DataSourceExec::from_data_source(config))
+}
+
+fn build_partition_values(
+    partition_fields: &[Arc<datafusion::arrow::datatypes::Field>],
+    partition: &HivePartition,
+) -> Result<Vec<ScalarValue>> {
+    partition_fields
+        .iter()
+        .zip(partition.partition_values.iter())
+        .map(|(field, val)| parse_partition_value(val, field.data_type()))
+        .collect()
 }
 
 fn filter_data_filters(filters: &[Expr], data_schema: &SchemaRef) -> Vec<Expr> {
@@ -439,83 +338,98 @@ fn build_parquet_exec(
     Ok(DataSourceExec::from_data_source(config))
 }
 
-// fn prune_partitions(
-//     partitions: &[HivePartitionInfo],
-//     partition_fields: &[FieldRef],
-//     filters: &[Expr],
-//     state: &dyn Session,
-// ) -> Result<Vec<usize>> {
-//     if filters.is_empty() || partition_fields.is_empty() {
-//         return Ok((0..partitions.len()).collect());
-//     }
-//
-//     let partition_schema = Arc::new(Schema::new(
-//         partition_fields
-//             .iter()
-//             .map(|f| f.as_ref().clone())
-//             .collect::<Vec<_>>(),
-//     ));
-//
-//     let partition_filters: Vec<&Expr> = filters
-//         .iter()
-//         .filter(|f| {
-//             f.column_refs()
-//                 .iter()
-//                 .all(|c| partition_schema.field_with_name(c.name()).is_ok())
-//         })
-//         .collect();
-//
-//     if partition_filters.is_empty() {
-//         return Ok((0..partitions.len()).collect());
-//     }
-//
-//     let df_schema = partition_schema.as_ref().clone().to_dfschema()?;
-//
-//     let mut columns: Vec<ArrayRef> = Vec::new();
-//     for (i, field) in partition_fields.iter().enumerate() {
-//         let values: Vec<Option<&str>> = partitions
-//             .iter()
-//             .map(|p| p.values.get(i).map(|s| s.as_str()))
-//             .collect();
-//         let array = build_partition_array(field.data_type(), &values)?;
-//         columns.push(array);
-//     }
-//
-//     let batch = datafusion::arrow::record_batch::RecordBatch::try_new(
-//         partition_schema.clone(),
-//         columns,
-//     )
-//     .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-//
-//     let mut surviving = Vec::new();
-//
-//     for row_idx in 0..partitions.len() {
-//         let mut keep = true;
-//         for filter_expr in &partition_filters {
-//             let physical_expr =
-//                 state.create_physical_expr((*filter_expr).clone(), &df_schema)?;
-//             let result = physical_expr.evaluate(&batch)?;
-//             let result_array = result.into_array(batch.num_rows())?;
-//             let bool_array = result_array
-//                 .as_any()
-//                 .downcast_ref::<BooleanArray>()
-//                 .ok_or_else(|| {
-//                     DataFusionError::Internal(
-//                         "partition filter did not produce boolean array".into(),
-//                     )
-//                 })?;
-//             if bool_array.is_null(row_idx) || !bool_array.value(row_idx) {
-//                 keep = false;
-//                 break;
-//             }
-//         }
-//         if keep {
-//             surviving.push(row_idx);
-//         }
-//     }
-//
-//     Ok(surviving)
-// }
+fn prune_partitions(
+    partitions: &[HivePartition],
+    partition_fields: &[Arc<Field>],
+    filters: &[Expr],
+    state: &dyn Session,
+) -> Result<Vec<usize>> {
+    if partition_fields.is_empty() {
+        return Err(DataFusionError::Internal("partition fields is empty".to_string()));
+    }
+    if filters.is_empty() {
+        return Ok((0..partitions.len()).collect());
+    }
+
+    let partition_schema = Arc::new(Schema::new(
+        partition_fields
+            .iter()
+            .map(|f| f.as_ref().clone())
+            .collect::<Vec<_>>(),
+    ));
+
+    let partition_col_name_set: HashSet<String> = partition_schema
+        .fields()
+        .iter()
+        .map(|field| field.name().to_ascii_lowercase())
+        .collect();
+
+    let partition_filters: Vec<&Expr> = filters
+        .iter()
+        .filter(|f| {
+            !f.column_refs().is_empty()
+                && f.column_refs()
+                    .iter()
+                    .all(|c| partition_col_name_set.contains(&c.name().to_ascii_lowercase()))
+        })
+        .collect();
+
+    if partition_filters.is_empty() {
+        return Ok((0..partitions.len()).collect());
+    }
+
+    let df_schema = partition_schema.as_ref().clone().to_dfschema()?;
+    let mut columns: Vec<ArrayRef> = Vec::with_capacity(partition_fields.len());
+    for (field_idx, field) in partition_fields.iter().enumerate() {
+        let values: Vec<Option<&str>> = partitions
+            .iter()
+            .map(|partition| {
+                partition
+                    .partition_values
+                    .get(field_idx)
+                    .map(|value| value.as_str())
+            })
+            .collect();
+        columns.push(build_partition_array(field.data_type(), &values)?);
+    }
+
+    let batch = RecordBatch::try_new(partition_schema, columns)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+    let compiled_filters = partition_filters
+        .into_iter()
+        .map(|filter| state.create_physical_expr(filter.clone(), &df_schema))
+        .collect::<Result<Vec<_>>>()?;
+
+    let mut filter_result: Option<BooleanArray> = None;
+    for filter in compiled_filters {
+        let result_array = filter.evaluate(&batch)?.to_array_of_size(batch.num_rows())?;
+        let bool_array = result_array
+            .as_any()
+            .downcast_ref::<BooleanArray>()
+            .ok_or_else(|| {
+                DataFusionError::Internal("partition filter did not produce boolean array".into())
+            })?;
+        filter_result = Some(match filter_result {
+            None => bool_array.clone(),
+            Some(acc) => compute::and(&acc, bool_array)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+        });
+    }
+
+    let mut surviving = Vec::new();
+    match filter_result {
+        None => surviving.extend(0..partitions.len()),
+        Some(combined_array) => {
+            for row_idx in 0..partitions.len() {
+                if !combined_array.is_null(row_idx) && combined_array.value(row_idx) {
+                    surviving.push(row_idx);
+                }
+            }
+        }
+    }
+
+    Ok(surviving)
+}
 
 #[allow(unused)]
 fn build_partition_array(data_type: &DataType, values: &[Option<&str>]) -> Result<ArrayRef> {
@@ -781,6 +695,10 @@ fn location_to_object_store_path(location: &str) -> Result<Path> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use datafusion::arrow::datatypes::Field;
+    use datafusion::logical_expr::expr::InList;
+    use datafusion::logical_expr::{Operator, binary_expr, col, lit};
+    use datafusion::prelude::SessionContext;
 
     #[test]
     fn test_location_to_object_store_path() {
@@ -804,5 +722,140 @@ mod tests {
             path.as_ref(),
             "hive/tpch_hive.db/textfile_partition_table/p=1"
         );
+    }
+
+    #[tokio::test]
+    async fn test_prune_partitions_eq() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[binary_expr(col("dt"), Operator::Eq, lit("2012-01-03"))],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_prune_partitions_in_list_and_gt() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let in_list = Expr::InList(InList::new(
+            Box::new(col("dt")),
+            vec![lit("2012-01-01"), lit("2012-01-04")],
+            false,
+        ));
+        let gt = binary_expr(col("dt"), Operator::Gt, lit("2012-01-01"));
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[in_list, gt],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![2]);
+    }
+
+    #[tokio::test]
+    async fn test_prune_partitions_ignores_mixed_data_filters() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[
+                binary_expr(col("dt"), Operator::Eq, lit("2012-01-03")),
+                binary_expr(col("c1"), Operator::Gt, lit(10_i32)),
+            ],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![1]);
+    }
+
+    #[tokio::test]
+    async fn test_prune_partitions_without_partition_filter_keeps_all() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = sample_partitions();
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[binary_expr(col("c1"), Operator::Gt, lit(10_i32))],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![0, 1, 2]);
+    }
+
+    #[tokio::test]
+    async fn test_prune_partitions_null_partition_does_not_match() {
+        let state = SessionContext::new();
+        let partition_fields = partition_fields();
+        let partitions = vec![
+            HivePartition {
+                location:
+                    "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=__HIVE_DEFAULT_PARTITION__"
+                        .to_string(),
+                partition_values: vec!["__HIVE_DEFAULT_PARTITION__".to_string()],
+            },
+            HivePartition {
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=".to_string(),
+                partition_values: vec!["".to_string()],
+            },
+            HivePartition {
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-03"
+                    .to_string(),
+                partition_values: vec!["2012-01-03".to_string()],
+            },
+        ];
+
+        let surviving = prune_partitions(
+            &partitions,
+            &partition_fields,
+            &[binary_expr(col("dt"), Operator::Eq, lit("2012-01-03"))],
+            &state.state(),
+        )
+        .unwrap();
+
+        assert_eq!(surviving, vec![2]);
+    }
+
+    fn partition_fields() -> Vec<Arc<Field>> {
+        vec![Arc::new(Field::new("dt", DataType::Utf8, true))]
+    }
+
+    fn sample_partitions() -> Vec<HivePartition> {
+        vec![
+            HivePartition {
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-01"
+                    .to_string(),
+                partition_values: vec!["2012-01-01".to_string()],
+            },
+            HivePartition {
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-03"
+                    .to_string(),
+                partition_values: vec!["2012-01-03".to_string()],
+            },
+            HivePartition {
+                location: "s3://warehouse/hive/tpch_hive.db/parquet_table/dt=2012-01-04"
+                    .to_string(),
+                partition_values: vec!["2012-01-04".to_string()],
+            },
+        ]
     }
 }

--- a/src/catalog/src/table_format/table_provider_factory.rs
+++ b/src/catalog/src/table_format/table_provider_factory.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 pub struct TableProviderBuilder {
     table_reference: TableReference,
     table_properties: HashMap<String, String>,
+    table_format: TableFormat,
     metadata_table_name: Option<String>,
     hive_storage_info: Option<HiveStorageInfo>,
     hive_partitions: Option<Vec<HivePartition>>,
@@ -26,6 +27,7 @@ impl TableProviderBuilder {
     pub fn new(
         table_reference: TableReference,
         table_properties: HashMap<String, String>,
+        table_format: TableFormat,
         catalog_config: CatalogConfig,
     ) -> Self {
         let storage_credential = match catalog_config {
@@ -35,6 +37,7 @@ impl TableProviderBuilder {
         Self {
             table_reference,
             table_properties,
+            table_format,
             metadata_table_name: None,
             hive_storage_info: None,
             hive_partitions: None,
@@ -47,18 +50,22 @@ impl TableProviderBuilder {
         self
     }
 
-    pub fn with_hive_storage_info(mut self, hive_storage_info: HiveStorageInfo) -> Self {
-        self.hive_storage_info = Some(hive_storage_info);
+    pub fn with_hive_storage_info(mut self, hive_storage_info: Option<HiveStorageInfo>) -> Self {
+        self.hive_storage_info = hive_storage_info;
         self
     }
 
-    pub fn with_hive_partitions(mut self, hive_partitions: Vec<HivePartition>) -> Self {
-        self.hive_partitions = Some(hive_partitions);
+    pub fn with_hive_partitions(mut self, hive_partitions: Option<Vec<HivePartition>>) -> Self {
+        self.hive_partitions = hive_partitions;
         self
+    }
+
+    pub fn table_format(&self) -> &TableFormat {
+        &self.table_format
     }
 
     pub async fn build(self) -> Result<Arc<dyn TableProvider>> {
-        match self.deduce_table_format()? {
+        match self.table_format {
             TableFormat::Iceberg => {
                 let iceberg_metadata_location =
                     self.table_properties.get("metadata_location").ok_or(
@@ -98,20 +105,6 @@ impl TableProviderBuilder {
             },
         }
     }
-
-    pub fn deduce_table_format(&self) -> Result<TableFormat> {
-        if self.table_properties.contains_key("metadata_location") {
-            return Ok(TableFormat::Iceberg);
-        }
-        if let Some(spark_provider) = self.table_properties.get("spark.sql.sources.provider")
-            && spark_provider == "DELTA"
-        {
-            return Ok(TableFormat::Delta);
-        }
-
-        // other table format fallback to hive format
-        Ok(TableFormat::Hive)
-    }
 }
 
 pub fn split_table_name(tbl_name: &str) -> (&str, Option<&str>) {
@@ -120,5 +113,46 @@ pub fn split_table_name(tbl_name: &str) -> (&str, Option<&str>) {
             (tmp_table_name, Some(tmp_metadata_table_name))
         }
         None => (tbl_name, None),
+    }
+}
+
+pub fn deduce_table_format(table_properties: &HashMap<String, String>) -> Result<TableFormat> {
+    if table_properties.contains_key("metadata_location") {
+        return Ok(TableFormat::Iceberg);
+    }
+    if let Some(spark_provider) = table_properties.get("spark.sql.sources.provider")
+        && spark_provider == "DELTA"
+    {
+        return Ok(TableFormat::Delta);
+    }
+
+    // other table format fallback to hive format
+    Ok(TableFormat::Hive)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_deduce_table_format() {
+        let table_properties =
+            HashMap::from([("metadata_location".to_string(), "path".to_string())]);
+        assert_eq!(
+            TableFormat::Iceberg,
+            deduce_table_format(&table_properties).unwrap()
+        );
+        let table_properties = HashMap::from([(
+            "spark.sql.sources.provider".to_string(),
+            "DELTA".to_string(),
+        )]);
+        assert_eq!(
+            TableFormat::Delta,
+            deduce_table_format(&table_properties).unwrap()
+        );
+        let table_properties = HashMap::from([]);
+        assert_eq!(
+            TableFormat::Hive,
+            deduce_table_format(&table_properties).unwrap()
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR improves Hive table query planning in the catalog layer by adding partition pruning support and making table provider construction table-format aware.

## Changes

- extract table format deduction into a reusable helper
- pass resolved table format into `TableProviderBuilder` instead of re-deducing it internally
- preload Hive storage info and partition metadata only for Hive tables in HMS
- align Glue catalog table provider creation with the new builder flow
- implement Hive partition pruning based on partition-only predicates
- correctly handle Hive default partition values such as `__HIVE_DEFAULT_PARTITION__` and empty partition values as `NULL`
- add unit tests for table format deduction and partition pruning behavior

## Motivation

Previously, Hive table scans could enumerate all partitions even when query predicates only targeted partition columns. This change allows us to prune partitions earlier and avoids unnecessary file listing and scan work.

## Impact

- improves query efficiency for partitioned Hive tables
- keeps Iceberg and Delta provider creation logic explicit and easier to maintain
- makes partition predicate handling more correct for null/default Hive partition values

## Notes

- this PR also includes `AGENTS.md`
