### PR TITLE
feat: add SHOW enhancements and shared runtime utilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2630,6 +2630,7 @@ dependencies = [
  "datafusion",
  "datafusion-cli",
  "dobbydb-catalog",
+ "dobbydb-common",
  "dobbydb-sql",
  "futures",
  "rustyline",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2601,6 +2601,7 @@ dependencies = [
  "datafusion",
  "deltalake",
  "deltalake-aws",
+ "dobbydb-common",
  "dobbydb-storage",
  "futures",
  "hive_metastore",
@@ -2612,6 +2613,13 @@ dependencies = [
  "toml",
  "url",
  "volo-thrift",
+]
+
+[[package]]
+name = "dobbydb-common"
+version = "0.1.0"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2642,9 +2642,11 @@ name = "dobbydb-sql"
 version = "0.1.0"
 dependencies = [
  "datafusion",
+ "datafusion-cli",
  "dobbydb-catalog",
  "sqlparser",
  "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,17 @@ edition = "2024"
 resolver = "2"
 members = [
     "src/catalog",
+    "src/common",
     "src/server",
     "src/sql",
-    "src/storage"]
+    "src/storage"
+]
 
 [workspace.dependencies]
 datafusion = "52.1.0"
 datafusion-cli = "52.1.0"
 sqlparser = "0.59.0"
-tokio = { version = "1.0", features = ["rt-multi-thread", "tracing"] }
+tokio = { version = "1.0", features = ["rt-multi-thread", "tracing", "rt"] }
 console-subscriber = "0.5.0"
 serde = { version = "1.0.228", features = ["derive"] }
 toml = "0.9.5"
@@ -30,3 +32,4 @@ dobbydb-catalog = { path = "src/catalog" }
 dobbydb-server = { path = "src/server" }
 dobbydb-sql = { path = "src/sql" }
 dobbydb-storage = {path = "src/storage"}
+dobbydb-common = {path = "src/common"}

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -5,6 +5,7 @@ edition = { workspace = true }
 
 [dependencies]
 dobbydb-storage = {workspace = true}
+dobbydb-common = {workspace = true}
 serde = { workspace = true }
 datafusion = { workspace = true }
 toml = { workspace = true }

--- a/src/catalog/src/data_file_format.rs
+++ b/src/catalog/src/data_file_format.rs
@@ -1,0 +1,1 @@
+pub mod parquet;

--- a/src/catalog/src/data_file_format/parquet.rs
+++ b/src/catalog/src/data_file_format/parquet.rs
@@ -1,0 +1,53 @@
+use datafusion::datasource::listing::PartitionedFile;
+use datafusion::datasource::physical_plan::parquet::ParquetFileReader;
+use datafusion::datasource::physical_plan::{ParquetFileMetrics, ParquetFileReaderFactory};
+use datafusion::object_store::ObjectStore;
+use datafusion::parquet::arrow::async_reader::{AsyncFileReader, ParquetObjectReader};
+use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
+use dobbydb_common::runtime::get_runtime_manager;
+use std::sync::Arc;
+use tokio::runtime::Handle;
+
+#[derive(Debug)]
+pub struct ExtendedParquetFileReaderFactory {
+    store: Arc<dyn ObjectStore>,
+    io_handle: Handle,
+}
+
+impl ExtendedParquetFileReaderFactory {
+    pub fn new(store: Arc<dyn ObjectStore>) -> Self {
+        let io_handle = get_runtime_manager().read().unwrap().io_handle();
+        Self { store, io_handle }
+    }
+}
+
+impl ParquetFileReaderFactory for ExtendedParquetFileReaderFactory {
+    fn create_reader(
+        &self,
+        partition_index: usize,
+        partitioned_file: PartitionedFile,
+        metadata_size_hint: Option<usize>,
+        metrics: &ExecutionPlanMetricsSet,
+    ) -> datafusion::common::Result<Box<dyn AsyncFileReader + Send>> {
+        let file_metrics = ParquetFileMetrics::new(
+            partition_index,
+            partitioned_file.object_meta.location.as_ref(),
+            metrics,
+        );
+        let store = Arc::clone(&self.store);
+        let mut inner =
+            ParquetObjectReader::new(store, partitioned_file.object_meta.location.clone())
+                .with_file_size(partitioned_file.object_meta.size)
+                .with_runtime(self.io_handle.clone());
+
+        if let Some(hint) = metadata_size_hint {
+            inner = inner.with_footer_size_hint(hint)
+        };
+
+        Ok(Box::new(ParquetFileReader {
+            inner,
+            file_metrics,
+            partitioned_file,
+        }))
+    }
+}

--- a/src/catalog/src/internal_catalog.rs
+++ b/src/catalog/src/internal_catalog.rs
@@ -7,6 +7,7 @@ use datafusion::catalog::{
     CatalogProvider, CatalogProviderList, MemorySchemaProvider, SchemaProvider,
 };
 use datafusion::common::Result;
+use datafusion::config::ConfigEntry;
 use datafusion::error::DataFusionError;
 use datafusion::execution::{SendableRecordBatchStream, TaskContext};
 use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
@@ -18,6 +19,7 @@ pub const INTERNAL_CATALOG: &str = "internal";
 pub const INFORMATION_SCHEMA_SHOW_CATALOGS: &str = "catalogs";
 pub const INFORMATION_SCHEMA_SHOW_SCHEMAS: &str = "schemas";
 pub const INFORMATION_SCHEMA_SHOW_TABLES: &str = "tables";
+pub const INFORMATION_SCHEMA_SHOW_VARIABLES: &str = "variables";
 
 #[derive(Debug)]
 pub struct InternalCatalog {
@@ -49,6 +51,14 @@ impl InternalCatalog {
             INFORMATION_SCHEMA_SHOW_TABLES.to_string(),
             Arc::new(InternalCatalog::wrap_with_stream_table(Arc::new(
                 InformationSchemaShowTables::new(catalog_provider_list.clone()),
+            ))?),
+        )?;
+
+        // show variables
+        information_schema.register_table(
+            INFORMATION_SCHEMA_SHOW_VARIABLES.to_string(),
+            Arc::new(InternalCatalog::wrap_with_stream_table(Arc::new(
+                InformationSchemaShowVariables::new(),
             ))?),
         )?;
         Ok(Self { information_schema })
@@ -294,6 +304,87 @@ impl PartitionStream for InformationSchemaShowTables {
             vec![Arc::new(table_name_builder.finish())],
         )
         .unwrap();
+        Box::pin(RecordBatchStreamAdapter::new(
+            Arc::clone(&self.schema),
+            futures::stream::once(async move { Ok(batch) }),
+        ))
+    }
+}
+
+#[derive(Debug)]
+struct InformationSchemaShowVariables {
+    schema: SchemaRef,
+}
+
+impl InformationSchemaShowVariables {
+    fn new() -> Self {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("name", DataType::Utf8, false),
+            Field::new("value", DataType::Utf8, true),
+            Field::new("description", DataType::Utf8, false),
+        ]));
+
+        Self { schema }
+    }
+
+    fn append_setting(
+        name_builder: &mut StringBuilder,
+        value_builder: &mut StringBuilder,
+        description_builder: &mut StringBuilder,
+        entry: ConfigEntry,
+    ) {
+        name_builder.append_value(entry.key);
+        value_builder.append_option(entry.value);
+        description_builder.append_value(entry.description);
+    }
+}
+
+impl PartitionStream for InformationSchemaShowVariables {
+    fn schema(&self) -> &SchemaRef {
+        &self.schema
+    }
+
+    fn execute(&self, ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
+        let mut name_builder = StringBuilder::new();
+        let mut value_builder = StringBuilder::new();
+        let mut description_builder = StringBuilder::new();
+
+        for entry in ctx.session_config().options().entries() {
+            Self::append_setting(
+                &mut name_builder,
+                &mut value_builder,
+                &mut description_builder,
+                entry,
+            );
+        }
+
+        for entry in ctx.runtime_env().config_entries() {
+            Self::append_setting(
+                &mut name_builder,
+                &mut value_builder,
+                &mut description_builder,
+                entry,
+            );
+        }
+
+        let batch = match RecordBatch::try_new(
+            Arc::clone(&self.schema),
+            vec![
+                Arc::new(name_builder.finish()),
+                Arc::new(value_builder.finish()),
+                Arc::new(description_builder.finish()),
+            ],
+        ) {
+            Ok(record_batch) => record_batch,
+            Err(error) => {
+                let error = DataFusionError::External(Box::new(error));
+                return Box::pin(RecordBatchStreamAdapter::new(
+                    self.schema.clone(),
+                    futures::stream::once(async move { Err(error) }),
+                ));
+            }
+        };
+
         Box::pin(RecordBatchStreamAdapter::new(
             Arc::clone(&self.schema),
             futures::stream::once(async move { Ok(batch) }),

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod catalog;
 pub mod constants;
+pub mod data_file_format;
 pub mod glue_catalog;
 pub mod hms_catalog;
 pub mod internal_catalog;

--- a/src/catalog/src/table_format/hive/hive_table_provider.rs
+++ b/src/catalog/src/table_format/hive/hive_table_provider.rs
@@ -1,3 +1,4 @@
+use crate::data_file_format::parquet::ExtendedParquetFileReaderFactory;
 use crate::table_format::hive::HiveStorageInfo;
 use crate::table_format::hive::hive_partition::HivePartition;
 use crate::table_format::hive::hive_storage_info::HiveInputFormat;
@@ -334,7 +335,14 @@ fn build_parquet_exec(
     parquet_options.global.pushdown_filters = true;
     parquet_options.global.reorder_filters = true;
 
-    let mut source = ParquetSource::new(table_schema).with_table_parquet_options(parquet_options);
+    let store = state.runtime_env().object_store(&store_url)?;
+
+    let parquet_file_reader_factory =
+        Arc::new(ExtendedParquetFileReaderFactory::new(store.clone()));
+
+    let mut source = ParquetSource::new(table_schema)
+        .with_table_parquet_options(parquet_options)
+        .with_parquet_file_reader_factory(parquet_file_reader_factory);
 
     let df_schema = data_schema.as_ref().clone().to_dfschema()?;
     let predicate = conjunction(filters.iter().cloned())

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dobbydb-common"
+version = { workspace = true }
+edition = { workspace = true }
+
+
+[dependencies]
+tokio = { workspace = true }

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod runtime;

--- a/src/common/src/runtime.rs
+++ b/src/common/src/runtime.rs
@@ -1,0 +1,31 @@
+use std::sync::{Arc, OnceLock, RwLock};
+use tokio::runtime::{Builder, Handle};
+
+static RUNTIME_MANAGER: OnceLock<RwLock<RuntimeManager>> = OnceLock::new();
+
+pub struct RuntimeManager {
+    io_runtime: Arc<tokio::runtime::Runtime>,
+}
+
+impl RuntimeManager {
+    fn new() -> Self {
+        let threads_num = std::thread::available_parallelism().unwrap().get() * 2;
+        let io_runtime = Arc::new(
+            Builder::new_multi_thread()
+                .worker_threads(threads_num)
+                .thread_name("io-runtime")
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+        Self { io_runtime }
+    }
+
+    pub fn io_handle(&self) -> Handle {
+        self.io_runtime.handle().clone()
+    }
+}
+
+pub fn get_runtime_manager() -> &'static RwLock<RuntimeManager> {
+    RUNTIME_MANAGER.get_or_init(|| RwLock::new(RuntimeManager::new()))
+}

--- a/src/common/src/runtime.rs
+++ b/src/common/src/runtime.rs
@@ -4,25 +4,39 @@ use tokio::runtime::{Builder, Handle};
 static RUNTIME_MANAGER: OnceLock<RwLock<RuntimeManager>> = OnceLock::new();
 
 pub struct RuntimeManager {
+    cpu_runtime: Arc<tokio::runtime::Runtime>,
     io_runtime: Arc<tokio::runtime::Runtime>,
 }
 
 impl RuntimeManager {
     fn new() -> Self {
-        let threads_num = std::thread::available_parallelism().unwrap().get() * 2;
+        let cpu_num = std::thread::available_parallelism().unwrap().get();
+        let cpu_runtime = Arc::new(
+            Builder::new_multi_thread()
+                .worker_threads(cpu_num * 2)
+                .thread_name("cpu-runtime")
+                .enable_all()
+                .build()
+                .unwrap(),
+        );
+
         let io_runtime = Arc::new(
             Builder::new_multi_thread()
-                .worker_threads(threads_num)
+                .worker_threads(cpu_num * 3)
                 .thread_name("io-runtime")
                 .enable_all()
                 .build()
                 .unwrap(),
         );
-        Self { io_runtime }
+        Self { cpu_runtime, io_runtime }
     }
 
     pub fn io_handle(&self) -> Handle {
         self.io_runtime.handle().clone()
+    }
+
+    pub fn cpu_handle(&self) -> Handle {
+        self.cpu_runtime.handle().clone()
     }
 }
 

--- a/src/common/src/runtime.rs
+++ b/src/common/src/runtime.rs
@@ -28,7 +28,10 @@ impl RuntimeManager {
                 .build()
                 .unwrap(),
         );
-        Self { cpu_runtime, io_runtime }
+        Self {
+            cpu_runtime,
+            io_runtime,
+        }
     }
 
     pub fn io_handle(&self) -> Handle {

--- a/src/server/Cargo.toml
+++ b/src/server/Cargo.toml
@@ -11,4 +11,5 @@ datafusion-cli = { workspace = true }
 tokio = { workspace = true }
 dobbydb-catalog = { workspace = true }
 dobbydb-sql = { workspace = true }
+dobbydb-common = { workspace = true}
 futures = { workspace = true }

--- a/src/server/src/exec.rs
+++ b/src/server/src/exec.rs
@@ -105,9 +105,8 @@ async fn exec_and_print(
     let now = Instant::now();
     let df = ctx.sql(sql).await?;
     let format_options = ctx.task_ctx().session_config().options().format.clone();
-
+    let mut stream = df.execute_stream().await?;
     if print_options.format == PrintFormat::Table {
-        let mut stream = df.execute_stream().await?;
         let schema = stream.schema();
         let mut row_count = 0_usize;
         let mut batches = Vec::new();
@@ -118,7 +117,6 @@ async fn exec_and_print(
         }
         print_options.print_batches(schema, &batches, now, row_count, &format_options)?;
     } else {
-        let stream = df.execute_stream().await?;
         print_options
             .print_stream(stream, now, &format_options)
             .await?;

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -37,10 +37,7 @@ impl DobbyDBServer {
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct DobbyDBArgs {
-    #[clap(
-        long,
-        help = "Specify config path",
-    )]
+    #[clap(long, help = "Specify config path")]
     config: String,
 
     #[clap(
@@ -70,8 +67,7 @@ async fn async_main() -> Result<()> {
     server.init().await?;
 
     let instrumented_registry = Arc::new(
-        InstrumentedObjectStoreRegistry::new()
-            .with_profile_mode(args.object_store_profiling),
+        InstrumentedObjectStoreRegistry::new().with_profile_mode(args.object_store_profiling),
     );
     let runtime_env = RuntimeEnvBuilder::new()
         .with_object_store_registry(instrumented_registry.clone())

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -2,13 +2,16 @@ mod exec;
 
 use clap::Parser;
 use datafusion::common::error::Result;
-use datafusion_cli::object_storage::instrumented::InstrumentedObjectStoreRegistry;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion_cli::object_storage::instrumented::{
+    InstrumentedObjectStoreMode, InstrumentedObjectStoreRegistry,
+};
 use datafusion_cli::print_format::PrintFormat;
 use datafusion_cli::print_options::{MaxRows, PrintOptions};
 use dobbydb_catalog::catalog::get_catalog_manager;
+use dobbydb_common::runtime::get_runtime_manager;
 use dobbydb_sql::session::ExtendedSessionContext;
 use std::sync::Arc;
-use dobbydb_common::runtime::get_runtime_manager;
 
 pub struct DobbyDBServer {
     config_path: String,
@@ -34,8 +37,18 @@ impl DobbyDBServer {
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct DobbyDBArgs {
-    #[arg(short, long)]
+    #[clap(
+        long,
+        help = "Specify config path",
+    )]
     config: String,
+
+    #[clap(
+        long,
+        help = "Specify the default object_store_profiling mode, defaults to 'disabled'.\n[possible values: disabled, summary, trace]",
+        default_value_t = InstrumentedObjectStoreMode::Disabled
+    )]
+    object_store_profiling: InstrumentedObjectStoreMode,
 
     #[clap(
         long,
@@ -45,7 +58,6 @@ struct DobbyDBArgs {
     )]
     command: Vec<String>,
 }
-
 
 pub fn main() -> Result<()> {
     let cpu_handle = get_runtime_manager().read().unwrap().cpu_handle();
@@ -57,14 +69,22 @@ async fn async_main() -> Result<()> {
     let server = DobbyDBServer::new(args.config.clone());
     server.init().await?;
 
+    let instrumented_registry = Arc::new(
+        InstrumentedObjectStoreRegistry::new()
+            .with_profile_mode(args.object_store_profiling),
+    );
+    let runtime_env = RuntimeEnvBuilder::new()
+        .with_object_store_registry(instrumented_registry.clone())
+        .build_arc()?;
+
     let print_options = PrintOptions {
         format: PrintFormat::Table,
         quiet: false,
         maxrows: MaxRows::Unlimited,
         color: true,
-        instrumented_registry: Arc::new(InstrumentedObjectStoreRegistry::default()),
+        instrumented_registry: instrumented_registry.clone(),
     };
-    let session_context = ExtendedSessionContext::new().await?;
+    let session_context = ExtendedSessionContext::new_with_runtime_env(runtime_env).await?;
     let commands = args.command;
     if commands.is_empty() {
         exec::exec_from_repl(&session_context, &print_options).await;

--- a/src/server/src/main.rs
+++ b/src/server/src/main.rs
@@ -8,6 +8,7 @@ use datafusion_cli::print_options::{MaxRows, PrintOptions};
 use dobbydb_catalog::catalog::get_catalog_manager;
 use dobbydb_sql::session::ExtendedSessionContext;
 use std::sync::Arc;
+use dobbydb_common::runtime::get_runtime_manager;
 
 pub struct DobbyDBServer {
     config_path: String,
@@ -45,8 +46,13 @@ struct DobbyDBArgs {
     command: Vec<String>,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+
+pub fn main() -> Result<()> {
+    let cpu_handle = get_runtime_manager().read().unwrap().cpu_handle();
+    cpu_handle.block_on(async_main())
+}
+
+async fn async_main() -> Result<()> {
     let args = DobbyDBArgs::parse();
     let server = DobbyDBServer::new(args.config.clone());
     server.init().await?;

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -8,3 +8,7 @@ datafusion = { workspace = true }
 sqlparser = { workspace = true }
 tokio = { workspace = true }
 dobbydb-catalog = { workspace = true }
+
+[dev-dependencies]
+datafusion-cli = { workspace = true }
+url = { workspace = true }

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::statements::ExtendedStatement;
+use crate::statements::{ExtendedStatement, ShowVariablesStatement};
 use datafusion::common::Result;
 use datafusion::common::{Diagnostic, Span};
 use datafusion::config::SqlParserOptions;
@@ -6,6 +6,7 @@ use datafusion::error::DataFusionError;
 use datafusion::logical_expr::sqlparser::keywords::Keyword;
 use datafusion::logical_expr::sqlparser::parser::{Parser, ParserError};
 use datafusion::logical_expr::sqlparser::tokenizer::{Token, TokenWithSpan, Tokenizer};
+use sqlparser::ast::ShowStatementFilter;
 use sqlparser::dialect::{DatabricksDialect, Dialect};
 use std::collections::VecDeque;
 
@@ -153,14 +154,35 @@ impl<'a> ExtendedParser<'a> {
     fn parse_show(&mut self) -> Result<ExtendedStatement> {
         let token = self.parser.peek_token();
         if let Token::Word(w) = &token.token {
-            let val = w.value.to_ascii_uppercase();
-            if val == "CATALOGS" {
+            if w.value.eq_ignore_ascii_case("catalogs") {
                 self.parser.advance_token();
                 return Ok(ExtendedStatement::ShowCatalogsStatement);
             }
-        };
+
+            if w.keyword == Keyword::VARIABLES {
+                self.parser.advance_token();
+                return self.parse_show_variables();
+            }
+        }
         Ok(ExtendedStatement::SQLStatement(Box::from(
             self.parser.parse_show()?,
+        )))
+    }
+
+    fn parse_show_variables(&mut self) -> Result<ExtendedStatement> {
+        let verbose = self.parser.parse_keyword(Keyword::VERBOSE);
+        let filter = if self.parser.parse_keyword(Keyword::LIKE) {
+            Some(ShowStatementFilter::Like(
+                self.parser
+                    .parse_literal_string()
+                    .map_err(DataFusionError::from)?,
+            ))
+        } else {
+            None
+        };
+
+        Ok(ExtendedStatement::ShowVariablesStatement(Box::new(
+            ShowVariablesStatement { filter, verbose },
         )))
     }
 
@@ -185,7 +207,8 @@ impl<'a> ExtendedParser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::statements::ExtendedStatement::SQLStatement;
+    use crate::statements::ExtendedStatement::{SQLStatement, ShowVariablesStatement as ShowVars};
+    use crate::statements::ShowVariablesStatement;
     use sqlparser::ast::{Ident, ObjectName, ObjectNamePart, ShowStatementOptions, Statement, Use};
 
     #[test]
@@ -223,6 +246,54 @@ mod tests {
                 limit_from: None,
                 filter_position: None,
             },
+        }));
+        assert_eq!(expected_statement, *stmt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_variables() -> Result<()> {
+        let statement = ExtendedParser::parse_sql("show variables")?;
+        let stmt = &statement[0];
+        let expected_statement = ShowVars(Box::new(ShowVariablesStatement {
+            filter: None,
+            verbose: false,
+        }));
+        assert_eq!(expected_statement, *stmt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_variables_like() -> Result<()> {
+        let statement = ExtendedParser::parse_sql("show variables like '%xxxxxxx%'")?;
+        let stmt = &statement[0];
+        let expected_statement = ShowVars(Box::new(ShowVariablesStatement {
+            filter: Some(ShowStatementFilter::Like("%xxxxxxx%".to_string())),
+            verbose: false,
+        }));
+        assert_eq!(expected_statement, *stmt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_variables_verbose() -> Result<()> {
+        let statement = ExtendedParser::parse_sql("show variables verbose")?;
+        let stmt = &statement[0];
+        let expected_statement = ShowVars(Box::new(ShowVariablesStatement {
+            filter: None,
+            verbose: true,
+        }));
+        assert_eq!(expected_statement, *stmt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_variables_verbose_like() -> Result<()> {
+        let statement = ExtendedParser::parse_sql("show variables verbose like '%xxxxxxx%'")?;
+        let stmt = &statement[0];
+        let expected_statement = ShowVars(Box::new(ShowVariablesStatement {
+            filter: Some(ShowStatementFilter::Like("%xxxxxxx%".to_string())),
+            verbose: true,
         }));
         assert_eq!(expected_statement, *stmt);
         Ok(())

--- a/src/sql/src/parser.rs
+++ b/src/sql/src/parser.rs
@@ -1,4 +1,4 @@
-use crate::statements::{ExtendedStatement, ShowVariablesStatement};
+use crate::statements::{ExtendedStatement, ShowCatalogsStatement, ShowVariablesStatement};
 use datafusion::common::Result;
 use datafusion::common::{Diagnostic, Span};
 use datafusion::config::SqlParserOptions;
@@ -156,7 +156,7 @@ impl<'a> ExtendedParser<'a> {
         if let Token::Word(w) = &token.token {
             if w.value.eq_ignore_ascii_case("catalogs") {
                 self.parser.advance_token();
-                return Ok(ExtendedStatement::ShowCatalogsStatement);
+                return self.parse_show_catalogs();
             }
 
             if w.keyword == Keyword::VARIABLES {
@@ -169,21 +169,33 @@ impl<'a> ExtendedParser<'a> {
         )))
     }
 
+    fn parse_show_catalogs(&mut self) -> Result<ExtendedStatement> {
+        Ok(ExtendedStatement::ShowCatalogsStatement(Box::new(
+            ShowCatalogsStatement {
+                filter: self.parse_show_like_filter()?,
+            },
+        )))
+    }
+
     fn parse_show_variables(&mut self) -> Result<ExtendedStatement> {
         let verbose = self.parser.parse_keyword(Keyword::VERBOSE);
-        let filter = if self.parser.parse_keyword(Keyword::LIKE) {
-            Some(ShowStatementFilter::Like(
-                self.parser
-                    .parse_literal_string()
-                    .map_err(DataFusionError::from)?,
-            ))
-        } else {
-            None
-        };
+        let filter = self.parse_show_like_filter()?;
 
         Ok(ExtendedStatement::ShowVariablesStatement(Box::new(
             ShowVariablesStatement { filter, verbose },
         )))
+    }
+
+    fn parse_show_like_filter(&mut self) -> Result<Option<ShowStatementFilter>> {
+        if self.parser.parse_keyword(Keyword::LIKE) {
+            Ok(Some(ShowStatementFilter::Like(
+                self.parser
+                    .parse_literal_string()
+                    .map_err(DataFusionError::from)?,
+            )))
+        } else {
+            Ok(None)
+        }
     }
 
     /// Helper method to parse a statement and handle errors consistently, especially for recursion limits
@@ -207,15 +219,36 @@ impl<'a> ExtendedParser<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::statements::ExtendedStatement::{SQLStatement, ShowVariablesStatement as ShowVars};
-    use crate::statements::ShowVariablesStatement;
-    use sqlparser::ast::{Ident, ObjectName, ObjectNamePart, ShowStatementOptions, Statement, Use};
+    use crate::statements::ExtendedStatement::{
+        SQLStatement, ShowCatalogsStatement as ShowCatalogs, ShowVariablesStatement as ShowVars,
+    };
+    use crate::statements::{ShowCatalogsStatement, ShowVariablesStatement};
+    use sqlparser::ast::{
+        Ident, ObjectName, ObjectNamePart, ShowStatementFilter, ShowStatementFilterPosition,
+        ShowStatementOptions, Statement, Use,
+    };
 
     #[test]
     fn test_show_catalogs() -> Result<()> {
         let statement = ExtendedParser::parse_sql("show catalogs")?;
         let stmt = &statement[0];
-        assert_eq!(ExtendedStatement::ShowCatalogsStatement, *stmt);
+        assert_eq!(
+            ShowCatalogs(Box::new(ShowCatalogsStatement { filter: None })),
+            *stmt
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_catalogs_like() -> Result<()> {
+        let statement = ExtendedParser::parse_sql("show catalogs like '%foo%'")?;
+        let stmt = &statement[0];
+        assert_eq!(
+            ShowCatalogs(Box::new(ShowCatalogsStatement {
+                filter: Some(ShowStatementFilter::Like("%foo%".to_string())),
+            })),
+            *stmt
+        );
         Ok(())
     }
 
@@ -245,6 +278,51 @@ mod tests {
                 limit: None,
                 limit_from: None,
                 filter_position: None,
+            },
+        }));
+        assert_eq!(expected_statement, *stmt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_schemas_like() -> Result<()> {
+        let statement = ExtendedParser::parse_sql("show schemas like '%foo%'")?;
+        let stmt = &statement[0];
+        let expected_statement = SQLStatement(Box::new(Statement::ShowSchemas {
+            terse: false,
+            history: false,
+            show_options: ShowStatementOptions {
+                show_in: None,
+                starts_with: None,
+                limit: None,
+                limit_from: None,
+                filter_position: Some(ShowStatementFilterPosition::Suffix(
+                    ShowStatementFilter::Like("%foo%".to_string()),
+                )),
+            },
+        }));
+        assert_eq!(expected_statement, *stmt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_tables_like() -> Result<()> {
+        let statement = ExtendedParser::parse_sql("show tables like '%foo%'")?;
+        let stmt = &statement[0];
+        let expected_statement = SQLStatement(Box::new(Statement::ShowTables {
+            terse: false,
+            history: false,
+            extended: false,
+            full: false,
+            external: false,
+            show_options: ShowStatementOptions {
+                show_in: None,
+                starts_with: None,
+                limit: None,
+                limit_from: None,
+                filter_position: Some(ShowStatementFilterPosition::Suffix(
+                    ShowStatementFilter::Like("%foo%".to_string()),
+                )),
             },
         }));
         assert_eq!(expected_statement, *stmt);

--- a/src/sql/src/session.rs
+++ b/src/sql/src/session.rs
@@ -8,12 +8,13 @@ use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::LogicalPlanBuilder;
-use datafusion::logical_expr::sqlparser::ast::{Statement, Use};
+use datafusion::logical_expr::sqlparser::ast::{ShowStatementFilter, Statement, Use};
 use datafusion::prelude::{SessionConfig, SessionContext};
 use dobbydb_catalog::catalog::{get_catalog_manager, register_catalogs_into_catalog_provider};
 use dobbydb_catalog::internal_catalog::{
     INFORMATION_SCHEMA_SHOW_CATALOGS, INFORMATION_SCHEMA_SHOW_SCHEMAS,
-    INFORMATION_SCHEMA_SHOW_TABLES, INTERNAL_CATALOG, InternalCatalog,
+    INFORMATION_SCHEMA_SHOW_TABLES, INFORMATION_SCHEMA_SHOW_VARIABLES, INTERNAL_CATALOG,
+    InternalCatalog,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, OnceLock, RwLock};
@@ -146,6 +147,11 @@ impl ExtendedSessionContext {
                     .build_sql(),
                 );
             }
+            ExtendedStatement::ShowVariablesStatement(show_variables) => {
+                sql_string = Some(
+                    self.build_show_variables_sql(&show_variables.filter, show_variables.verbose)?,
+                );
+            }
             ExtendedStatement::SQLStatement(stmt) => match stmt.as_ref() {
                 Statement::Use(use_stmt) => {
                     return self.handle_use_stmt(use_stmt).await;
@@ -187,6 +193,34 @@ impl ExtendedSessionContext {
 
     pub fn task_ctx(&self) -> Arc<TaskContext> {
         self.session_context.task_ctx()
+    }
+
+    fn build_show_variables_sql(
+        &self,
+        filter: &Option<ShowStatementFilter>,
+        verbose: bool,
+    ) -> Result<String> {
+        let columns = if verbose {
+            "name, value, description"
+        } else {
+            "name, value"
+        };
+        let base_sql = format!(
+            "SELECT {columns} FROM {}.{}.{}",
+            INTERNAL_CATALOG, INFORMATION_SCHEMA, INFORMATION_SCHEMA_SHOW_VARIABLES
+        );
+
+        let base_sql = match filter {
+            None => base_sql,
+            Some(ShowStatementFilter::Like(pattern)) => {
+                let escaped_pattern = pattern.replace('\'', "''");
+                format!("{base_sql} WHERE name LIKE '{escaped_pattern}'")
+            }
+            _ => return Err(DataFusionError::Plan(
+                "SHOW VARIABLES only supports LIKE filters".to_string(),
+            )),
+        };
+        Ok(format!("{base_sql} ORDER BY NAME"))
     }
 
     async fn handle_use_stmt(&self, use_stmt: &Use) -> Result<DataFrame> {
@@ -265,5 +299,76 @@ impl ExtendedSessionContext {
         self.session_context
             .execute_logical_plan(empty_logical_plan)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::util::pretty::pretty_format_batches;
+    use datafusion::common::assert_contains;
+
+    #[tokio::test]
+    async fn test_show_variables_execution() -> Result<()> {
+        let session = ExtendedSessionContext::new().await?;
+        let batches = session.sql("show variables").await?.collect().await?;
+        let schema = batches[0].schema();
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.field(0).name(), "name");
+        assert_eq!(schema.field(1).name(), "value");
+        assert_contains!(output.as_str(), "datafusion.execution.target_partitions");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_variables_verbose_execution() -> Result<()> {
+        let session = ExtendedSessionContext::new().await?;
+        let batches = session
+            .sql("show variables verbose")
+            .await?
+            .collect()
+            .await?;
+        let schema = batches[0].schema();
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_eq!(schema.fields().len(), 3);
+        assert_eq!(schema.field(0).name(), "name");
+        assert_eq!(schema.field(1).name(), "value");
+        assert_eq!(schema.field(2).name(), "description");
+        assert_contains!(output.as_str(), "datafusion.execution.target_partitions");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_variables_like_execution() -> Result<()> {
+        let session = ExtendedSessionContext::new().await?;
+        let batches = session
+            .sql("show variables like '%target_partitions%'")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_contains!(output, "datafusion.execution.target_partitions");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_variables_verbose_like_execution() -> Result<()> {
+        let session = ExtendedSessionContext::new().await?;
+        let batches = session
+            .sql("show variables verbose like '%target_partitions%'")
+            .await?
+            .collect()
+            .await?;
+        let schema = batches[0].schema();
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_eq!(schema.fields().len(), 3);
+        assert_eq!(schema.field(2).name(), "description");
+        assert_contains!(output.as_str(), "datafusion.execution.target_partitions");
+        Ok(())
     }
 }

--- a/src/sql/src/session.rs
+++ b/src/sql/src/session.rs
@@ -7,6 +7,7 @@ use datafusion::common::TableReference;
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::TaskContext;
+use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::logical_expr::LogicalPlanBuilder;
 use datafusion::logical_expr::sqlparser::ast::{ShowStatementFilter, Statement, Use};
 use datafusion::prelude::{SessionConfig, SessionContext};
@@ -104,9 +105,13 @@ pub struct ExtendedSessionContext {
 
 impl ExtendedSessionContext {
     pub async fn new() -> Result<Self> {
+        Self::new_with_runtime_env(Arc::new(RuntimeEnv::default())).await
+    }
+
+    pub async fn new_with_runtime_env(runtime_env: Arc<RuntimeEnv>) -> Result<Self> {
         let session_config = SessionConfig::new()
             .with_default_catalog_and_schema(INTERNAL_CATALOG, INFORMATION_SCHEMA);
-        let session_context = SessionContext::new_with_config(session_config);
+        let session_context = SessionContext::new_with_config_rt(session_config, runtime_env);
         let memory_catalog_provider_list = Arc::new(MemoryCatalogProviderList::new());
 
         let all_catalogs = get_catalog_manager().read().unwrap().get_all_catalogs();
@@ -193,6 +198,10 @@ impl ExtendedSessionContext {
 
     pub fn task_ctx(&self) -> Arc<TaskContext> {
         self.session_context.task_ctx()
+    }
+
+    pub fn session_context(&self) -> &SessionContext {
+        &self.session_context
     }
 
     fn build_show_variables_sql(
@@ -307,8 +316,19 @@ impl ExtendedSessionContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bytes::Bytes;
     use datafusion::arrow::util::pretty::pretty_format_batches;
     use datafusion::common::assert_contains;
+    use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+    use datafusion::prelude::CsvReadOptions;
+    use datafusion_cli::object_storage::instrumented::{
+        InstrumentedObjectStoreMode, InstrumentedObjectStoreRegistry,
+    };
+    use object_store::memory::InMemory;
+    use object_store::path::Path;
+    use object_store::{ObjectStore, PutPayload};
+    use std::sync::Arc;
+    use url::Url;
 
     #[tokio::test]
     async fn test_show_variables_execution() -> Result<()> {
@@ -371,6 +391,53 @@ mod tests {
         assert_eq!(schema.fields().len(), 3);
         assert_eq!(schema.field(2).name(), "description");
         assert_contains!(output.as_str(), "datafusion.execution.target_partitions");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_instrumented_object_store_registry_records_requests() -> Result<()> {
+        let instrumented_registry = Arc::new(
+            InstrumentedObjectStoreRegistry::new()
+                .with_profile_mode(InstrumentedObjectStoreMode::Summary),
+        );
+        let runtime_env = RuntimeEnvBuilder::new()
+            .with_object_store_registry(instrumented_registry.clone())
+            .build_arc()?;
+        let session = ExtendedSessionContext::new_with_runtime_env(runtime_env).await?;
+
+        let store_url = Url::parse("memory://bucket").unwrap();
+        let object_store = Arc::new(InMemory::new());
+        object_store
+            .put(
+                &Path::from("data.csv"),
+                PutPayload::from(Bytes::from_static(b"id,value\n1,alpha\n2,beta\n")),
+            )
+            .await
+            .map_err(|err| DataFusionError::External(Box::new(err)))?;
+        session
+            .session_context()
+            .register_object_store(&store_url, object_store);
+        session
+            .session_context()
+            .register_csv(
+                "instrumented_csv",
+                "memory://bucket/data.csv",
+                CsvReadOptions::default(),
+            )
+            .await?;
+
+        let batches = session
+            .sql("select count(*) as cnt from instrumented_csv")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_contains!(output.as_str(), "| 2   |");
+        assert!(!instrumented_registry.stores().is_empty());
+
+        let requests = instrumented_registry.stores()[0].take_requests();
+        assert!(!requests.is_empty());
         Ok(())
     }
 }

--- a/src/sql/src/session.rs
+++ b/src/sql/src/session.rs
@@ -1,15 +1,16 @@
 use crate::parser::ExtendedParser;
-use crate::statements::ExtendedStatement;
+use crate::statements::{ExtendedStatement, ShowCatalogsStatement};
 use datafusion::catalog::information_schema::INFORMATION_SCHEMA;
 use datafusion::catalog::{CatalogProviderList, MemoryCatalogProviderList};
 use datafusion::common::Result;
-use datafusion::common::TableReference;
 use datafusion::dataframe::DataFrame;
 use datafusion::error::DataFusionError;
 use datafusion::execution::TaskContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::logical_expr::LogicalPlanBuilder;
-use datafusion::logical_expr::sqlparser::ast::{ShowStatementFilter, Statement, Use};
+use datafusion::logical_expr::sqlparser::ast::{
+    ShowStatementFilter, ShowStatementFilterPosition, ShowStatementOptions, Statement, Use,
+};
 use datafusion::prelude::{SessionConfig, SessionContext};
 use dobbydb_catalog::catalog::{get_catalog_manager, register_catalogs_into_catalog_provider};
 use dobbydb_catalog::internal_catalog::{
@@ -60,45 +61,6 @@ impl SessionManager {
     }
 }
 
-struct ScanVirtualTableSqlBuilder {
-    catalog_name: String,
-    schema_name: String,
-    table_name: String,
-}
-
-impl ScanVirtualTableSqlBuilder {
-    fn new_with_table_reference(table_reference: TableReference) -> ScanVirtualTableSqlBuilder {
-        match table_reference {
-            TableReference::Bare { table } => Self {
-                catalog_name: String::from(INTERNAL_CATALOG),
-                schema_name: String::from(INFORMATION_SCHEMA),
-                table_name: String::from(table.as_ref()),
-            },
-            TableReference::Partial { schema, table } => Self {
-                catalog_name: String::from(INTERNAL_CATALOG),
-                schema_name: String::from(schema.as_ref()),
-                table_name: String::from(table.as_ref()),
-            },
-            TableReference::Full {
-                catalog,
-                schema,
-                table,
-            } => Self {
-                catalog_name: String::from(catalog.as_ref()),
-                schema_name: String::from(schema.as_ref()),
-                table_name: String::from(table.as_ref()),
-            },
-        }
-    }
-
-    fn build_sql(&self) -> String {
-        format!(
-            "SELECT * FROM {}.{}.{}",
-            self.catalog_name, self.schema_name, self.table_name
-        )
-    }
-}
-
 pub struct ExtendedSessionContext {
     session_context: SessionContext,
 }
@@ -142,58 +104,28 @@ impl ExtendedSessionContext {
     }
 
     pub async fn create_dataframe(&self, statement: &ExtendedStatement) -> Result<DataFrame> {
-        let sql_string: Option<String>;
-        match statement {
-            ExtendedStatement::ShowCatalogsStatement => {
-                sql_string = Some(
-                    ScanVirtualTableSqlBuilder::new_with_table_reference(TableReference::Bare {
-                        table: Arc::from(INFORMATION_SCHEMA_SHOW_CATALOGS),
-                    })
-                    .build_sql(),
-                );
+        let sql_string: String = match statement {
+            ExtendedStatement::ShowCatalogsStatement(show_catalogs) => {
+                self.build_show_catalogs_sql(show_catalogs)?
             }
             ExtendedStatement::ShowVariablesStatement(show_variables) => {
-                sql_string = Some(
-                    self.build_show_variables_sql(&show_variables.filter, show_variables.verbose)?,
-                );
+                self.build_show_variables_sql(&show_variables.filter, show_variables.verbose)?
             }
             ExtendedStatement::SQLStatement(stmt) => match stmt.as_ref() {
                 Statement::Use(use_stmt) => {
                     return self.handle_use_stmt(use_stmt).await;
                 }
-                Statement::ShowSchemas { .. } => {
-                    sql_string = Some(
-                        ScanVirtualTableSqlBuilder::new_with_table_reference(
-                            TableReference::Bare {
-                                table: Arc::from(INFORMATION_SCHEMA_SHOW_SCHEMAS),
-                            },
-                        )
-                        .build_sql(),
-                    );
+                Statement::ShowSchemas { show_options, .. } => {
+                    self.build_show_schemas_sql(show_options)?
                 }
-                Statement::ShowTables { .. } => {
-                    sql_string = Some(
-                        ScanVirtualTableSqlBuilder::new_with_table_reference(
-                            TableReference::Bare {
-                                table: Arc::from(INFORMATION_SCHEMA_SHOW_TABLES),
-                            },
-                        )
-                        .build_sql(),
-                    );
+                Statement::ShowTables { show_options, .. } => {
+                    self.build_show_tables_sql(show_options)?
                 }
-                _ => {
-                    sql_string = Some(stmt.to_string());
-                }
+                _ => stmt.to_string(),
             },
-        }
+        };
 
-        if let Some(sql) = sql_string {
-            self.session_context.sql(&sql).await
-        } else {
-            Err(DataFusionError::Plan(String::from(
-                "failed to create logical plan",
-            )))
-        }
+        self.session_context.sql(&sql_string).await
     }
 
     pub fn task_ctx(&self) -> Arc<TaskContext> {
@@ -222,8 +154,10 @@ impl ExtendedSessionContext {
         let base_sql = match filter {
             None => base_sql,
             Some(ShowStatementFilter::Like(pattern)) => {
-                let escaped_pattern = pattern.replace('\'', "''");
-                format!("{base_sql} WHERE name LIKE '{escaped_pattern}'")
+                format!(
+                    "{base_sql} WHERE name LIKE '{}'",
+                    Self::escape_sql_string(pattern)
+                )
             }
             _ => {
                 return Err(DataFusionError::Plan(
@@ -232,6 +166,72 @@ impl ExtendedSessionContext {
             }
         };
         Ok(format!("{base_sql} ORDER BY NAME"))
+    }
+
+    fn build_show_catalogs_sql(&self, show_catalogs: &ShowCatalogsStatement) -> Result<String> {
+        self.build_filtered_virtual_table_sql(
+            INFORMATION_SCHEMA_SHOW_CATALOGS,
+            "catalog_name",
+            &show_catalogs.filter,
+        )
+    }
+
+    fn build_show_schemas_sql(&self, show_options: &ShowStatementOptions) -> Result<String> {
+        self.build_filtered_virtual_table_sql(
+            INFORMATION_SCHEMA_SHOW_SCHEMAS,
+            "schema_name",
+            &Self::show_like_filter(show_options),
+        )
+    }
+
+    fn build_show_tables_sql(&self, show_options: &ShowStatementOptions) -> Result<String> {
+        self.build_filtered_virtual_table_sql(
+            INFORMATION_SCHEMA_SHOW_TABLES,
+            "table_name",
+            &Self::show_like_filter(show_options),
+        )
+    }
+
+    fn show_like_filter(show_options: &ShowStatementOptions) -> Option<ShowStatementFilter> {
+        match &show_options.filter_position {
+            None => None,
+            Some(ShowStatementFilterPosition::Infix(filter))
+            | Some(ShowStatementFilterPosition::Suffix(filter)) => match filter {
+                ShowStatementFilter::Like(pattern) => {
+                    Some(ShowStatementFilter::Like(pattern.clone()))
+                }
+                _ => None,
+            },
+        }
+    }
+
+    fn build_filtered_virtual_table_sql(
+        &self,
+        table_name: &str,
+        column_name: &str,
+        filter: &Option<ShowStatementFilter>,
+    ) -> Result<String> {
+        let base_sql = format!(
+            "SELECT * FROM {}.{}.{}",
+            INTERNAL_CATALOG, INFORMATION_SCHEMA, table_name
+        );
+
+        let base_sql = match filter {
+            None => base_sql,
+            Some(ShowStatementFilter::Like(pattern)) => {
+                format!(
+                    "{base_sql} WHERE {column_name} LIKE '{}'",
+                    Self::escape_sql_string(pattern)
+                )
+            }
+            _ => base_sql,
+        };
+
+        Ok(format!("{base_sql} ORDER BY {column_name}"))
+    }
+
+    fn escape_sql_string(value: &str) -> String {
+        value.replace('\'', "''")
     }
 
     async fn handle_use_stmt(&self, use_stmt: &Use) -> Result<DataFrame> {
@@ -316,17 +316,16 @@ impl ExtendedSessionContext {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bytes::Bytes;
     use datafusion::arrow::util::pretty::pretty_format_batches;
     use datafusion::common::assert_contains;
     use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+    use datafusion::object_store::memory::InMemory;
+    use datafusion::object_store::path::Path;
+    use datafusion::object_store::{ObjectStore, PutPayload};
     use datafusion::prelude::CsvReadOptions;
     use datafusion_cli::object_storage::instrumented::{
         InstrumentedObjectStoreMode, InstrumentedObjectStoreRegistry,
     };
-    use object_store::memory::InMemory;
-    use object_store::path::Path;
-    use object_store::{ObjectStore, PutPayload};
     use std::sync::Arc;
     use url::Url;
 
@@ -395,6 +394,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_show_catalogs_execution() -> Result<()> {
+        let session = ExtendedSessionContext::new().await?;
+        let batches = session.sql("show catalogs").await?.collect().await?;
+        let schema = batches[0].schema();
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_eq!(schema.fields().len(), 3);
+        assert_eq!(schema.field(0).name(), "catalog_name");
+        assert_contains!(output.as_str(), "internal");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_catalogs_like_execution() -> Result<()> {
+        let session = ExtendedSessionContext::new().await?;
+        let batches = session
+            .sql("show catalogs like '%tern%'")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_contains!(output.as_str(), "internal");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_schemas_like_execution() -> Result<()> {
+        let session = ExtendedSessionContext::new().await?;
+        let batches = session
+            .sql("show schemas like '%formation%'")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_contains!(output.as_str(), "information_schema");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_tables_like_execution() -> Result<()> {
+        let session = ExtendedSessionContext::new().await?;
+        let batches = session
+            .sql("show tables like '%table%'")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+        println!("{}", output);
+
+        assert_contains!(output.as_str(), "tables");
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_like_sql_escapes_quotes() -> Result<()> {
+        let session_context = SessionContext::new();
+        let session = ExtendedSessionContext { session_context };
+        let sql = session.build_filtered_virtual_table_sql(
+            INFORMATION_SCHEMA_SHOW_CATALOGS,
+            "catalog_name",
+            &Some(ShowStatementFilter::Like("%o''hara%".to_string())),
+        )?;
+
+        assert_contains!(sql.as_str(), "LIKE '%o''''hara%'");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_instrumented_object_store_registry_records_requests() -> Result<()> {
         let instrumented_registry = Arc::new(
             InstrumentedObjectStoreRegistry::new()
@@ -410,7 +479,7 @@ mod tests {
         object_store
             .put(
                 &Path::from("data.csv"),
-                PutPayload::from(Bytes::from_static(b"id,value\n1,alpha\n2,beta\n")),
+                PutPayload::from_static(b"id,value\n1,alpha\n2,beta\n"),
             )
             .await
             .map_err(|err| DataFusionError::External(Box::new(err)))?;

--- a/src/sql/src/session.rs
+++ b/src/sql/src/session.rs
@@ -216,9 +216,11 @@ impl ExtendedSessionContext {
                 let escaped_pattern = pattern.replace('\'', "''");
                 format!("{base_sql} WHERE name LIKE '{escaped_pattern}'")
             }
-            _ => return Err(DataFusionError::Plan(
-                "SHOW VARIABLES only supports LIKE filters".to_string(),
-            )),
+            _ => {
+                return Err(DataFusionError::Plan(
+                    "SHOW VARIABLES only supports LIKE filters".to_string(),
+                ));
+            }
         };
         Ok(format!("{base_sql} ORDER BY NAME"))
     }

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -1,7 +1,14 @@
-use sqlparser::ast::Statement as SQLStatement;
+use sqlparser::ast::{ShowStatementFilter, Statement as SQLStatement};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShowVariablesStatement {
+    pub filter: Option<ShowStatementFilter>,
+    pub verbose: bool,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExtendedStatement {
     SQLStatement(Box<SQLStatement>),
     ShowCatalogsStatement,
+    ShowVariablesStatement(Box<ShowVariablesStatement>),
 }

--- a/src/sql/src/statements.rs
+++ b/src/sql/src/statements.rs
@@ -1,6 +1,11 @@
 use sqlparser::ast::{ShowStatementFilter, Statement as SQLStatement};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShowCatalogsStatement {
+    pub filter: Option<ShowStatementFilter>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShowVariablesStatement {
     pub filter: Option<ShowStatementFilter>,
     pub verbose: bool,
@@ -9,6 +14,6 @@ pub struct ShowVariablesStatement {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ExtendedStatement {
     SQLStatement(Box<SQLStatement>),
-    ShowCatalogsStatement,
+    ShowCatalogsStatement(Box<ShowCatalogsStatement>),
     ShowVariablesStatement(Box<ShowVariablesStatement>),
 }


### PR DESCRIPTION
## Summary

- implement `SHOW VARIABLES` with verbose output and `LIKE` filtering support
- add `LIKE` support for `SHOW CATALOGS`, `SHOW SCHEMAS`, and `SHOW TABLES`
- introduce shared runtime utilities for parquet readers and a dedicated CPU runtime for server execution
- add object store profiling support for CLI queries

## Testing

- Not run in this PR flow