### PR TITLE
Add Hive table support for Glue catalog queries

### DIFF
--- a/src/catalog/src/glue_catalog.rs
+++ b/src/catalog/src/glue_catalog.rs
@@ -1,4 +1,7 @@
 use crate::catalog::CatalogConfig;
+use crate::table_format::TableFormat;
+use crate::table_format::hive::hive_partition::HivePartition;
+use crate::table_format::hive::hive_storage_info::HiveStorageInfo;
 use crate::table_format::table_provider_factory::{
     TableProviderBuilder, deduce_table_format, split_table_name,
 };
@@ -132,9 +135,9 @@ impl SchemaProvider for GlueSchema {
     }
 
     async fn table(&self, tbl_name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
-        let (table_name, _metadata_table_name) = split_table_name(tbl_name);
+        let (table_name, metadata_table_name) = split_table_name(tbl_name);
 
-        if !self.table_exist(table_name) {
+        if !self.table_exist(tbl_name) {
             return Ok(None);
         }
 
@@ -167,6 +170,40 @@ impl SchemaProvider for GlueSchema {
         };
 
         let table_format = deduce_table_format(&glue_table_properties)?;
+        let (hive_storage_info, hive_partitions) = if table_format == TableFormat::Hive {
+            let hive_storage_info = HiveStorageInfo::try_new_from_glue_table(&glue_table)?;
+            let hive_partitions = if !hive_storage_info
+                .table_schema
+                .table_partition_cols()
+                .is_empty()
+            {
+                // todo not checked
+                let paginator = glue_client
+                    .get_partitions()
+                    .database_name(&self.schema_name)
+                    .table_name(table_name)
+                    .into_paginator()
+                    .send();
+                tokio::pin!(paginator);
+
+                let mut partitions = Vec::new();
+                while let Some(page) = paginator.next().await {
+                    let page = page.map_err(|e| DataFusionError::External(Box::new(e)))?;
+                    partitions.extend(
+                        page.partitions()
+                            .iter()
+                            .map(HivePartition::try_new_from_glue_partition)
+                            .collect::<Result<Vec<_>>>()?,
+                    );
+                }
+                partitions
+            } else {
+                vec![]
+            };
+            (Some(hive_storage_info), Some(hive_partitions))
+        } else {
+            (None, None)
+        };
 
         let table_provider_builder = TableProviderBuilder::new(
             table_reference,
@@ -174,6 +211,10 @@ impl SchemaProvider for GlueSchema {
             table_format,
             CatalogConfig::GLUE(self.config.deref().clone()),
         );
+        let table_provider_builder = table_provider_builder
+            .with_table_metadata_table_name(metadata_table_name.map(|t| t.to_string()))
+            .with_hive_storage_info(hive_storage_info)
+            .with_hive_partitions(hive_partitions);
 
         Ok(Some(table_provider_builder.build().await?))
     }

--- a/src/catalog/src/hms_catalog.rs
+++ b/src/catalog/src/hms_catalog.rs
@@ -213,10 +213,9 @@ impl SchemaProvider for HMSSchema {
             CatalogConfig::HMS(self.config.deref().clone()),
         );
         let table_provider_builder = table_provider_builder
-            .with_table_metadata_table_name(metadata_table_name.map(|t| t.to_string()));
-        let table_provider_builder =
-            table_provider_builder.with_hive_storage_info(hive_storage_info);
-        let table_provider_builder = table_provider_builder.with_hive_partitions(hive_partitions);
+            .with_table_metadata_table_name(metadata_table_name.map(|t| t.to_string()))
+            .with_hive_storage_info(hive_storage_info)
+            .with_hive_partitions(hive_partitions);
         Ok(Some(table_provider_builder.build().await?))
     }
 

--- a/src/catalog/src/table_format/hive/hive_partition.rs
+++ b/src/catalog/src/table_format/hive/hive_partition.rs
@@ -1,6 +1,7 @@
+use aws_sdk_glue::types::Partition as GluePartition;
 use datafusion::common::Result;
 use datafusion::error::DataFusionError;
-use hive_metastore::Partition;
+use hive_metastore::Partition as HMSPartition;
 
 #[derive(Debug)]
 pub struct HivePartition {
@@ -9,31 +10,34 @@ pub struct HivePartition {
 }
 
 impl HivePartition {
-    pub fn try_new_from_hms_partition(partition: &Partition) -> Result<Self> {
-        let sd = match &partition.sd {
-            Some(sd) => sd,
-            None => {
-                return Err(DataFusionError::Internal(String::from(
-                    "partition sd not existed",
-                )));
-            }
-        };
-        let location = match &sd.location {
-            Some(location) => location.to_string(),
-            None => {
-                return Err(DataFusionError::Internal(String::from(
-                    "partition sd location not existed",
-                )));
-            }
-        };
-        let partition_values = match &partition.values {
-            Some(partition) => partition.iter().map(|v| v.to_string()).collect(),
-            None => {
-                return Err(DataFusionError::Internal(String::from(
-                    "partition values existed",
-                )));
-            }
-        };
+    pub fn try_new_from_hms_partition(partition: &HMSPartition) -> Result<Self> {
+        let sd = partition
+            .sd
+            .as_ref()
+            .ok_or_else(|| DataFusionError::Internal("partition sd not existed".to_string()))?;
+        Self::try_new(
+            sd.location.as_deref(),
+            partition
+                .values
+                .as_ref()
+                .map(|partition| partition.iter().map(|v| v.to_string()).collect()),
+        )
+    }
+
+    pub fn try_new_from_glue_partition(partition: &GluePartition) -> Result<Self> {
+        let sd = partition
+            .storage_descriptor()
+            .ok_or_else(|| DataFusionError::Internal("partition sd not existed".to_string()))?;
+        Self::try_new(sd.location(), partition.values.clone())
+    }
+
+    fn try_new(location: Option<&str>, partition_values: Option<Vec<String>>) -> Result<Self> {
+        let location = location.map(ToString::to_string).ok_or_else(|| {
+            DataFusionError::Internal("partition sd location not existed".to_string())
+        })?;
+        let partition_values = partition_values
+            .ok_or_else(|| DataFusionError::Internal("partition values not existed".to_string()))?;
+
         Ok(HivePartition {
             location,
             partition_values,

--- a/src/catalog/src/table_format/hive/hive_storage_info.rs
+++ b/src/catalog/src/table_format/hive/hive_storage_info.rs
@@ -1,8 +1,9 @@
 use crate::table_format::hive::hive_type::hive_type_to_arrow_type;
+use aws_sdk_glue::types::{Column as GlueColumn, Table as GlueTable};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::datasource::table_schema::TableSchema;
 use deltalake::arrow::datatypes::{Field, Schema};
-use hive_metastore::{FieldSchema, Table};
+use hive_metastore::{FieldSchema, Table as HMSTable};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -22,35 +23,13 @@ pub struct HiveStorageInfo {
 }
 
 impl HiveStorageInfo {
-    pub fn try_new_from_hms_table(table: &Table) -> Result<Self> {
-        let sd = if let Some(sd) = &table.sd {
-            sd
-        } else {
-            return Err(DataFusionError::Internal(String::from(
-                "Storage descriptor not existed",
-            )));
-        };
-        let table_location = match &sd.location {
-            Some(l) => l.to_string(),
-            None => {
-                return Err(DataFusionError::Internal(String::from(
-                    "location not exist",
-                )));
-            }
-        };
-        let input_format = match &sd.input_format {
-            Some(str) => Self::try_get_input_format(str.as_str())?,
-            None => {
-                return Err(DataFusionError::Internal(String::from(
-                    "input format not existed",
-                )));
-            }
-        };
-
-        let data_cols = Self::extract_field_schemas(&sd.cols)?;
-        let table_partition_cols = Self::extract_field_schemas(&table.partition_keys)?;
-
-        let serde_properties: HashMap<String, String> = sd
+    pub fn try_new_from_hms_table(table: &HMSTable) -> Result<Self> {
+        let sd = table.sd.as_ref().ok_or_else(|| {
+            DataFusionError::Internal("Storage descriptor not existed".to_string())
+        })?;
+        let data_cols = Self::extract_hms_field_schemas(&sd.cols)?;
+        let table_partition_cols = Self::extract_hms_field_schemas(&table.partition_keys)?;
+        let serde_properties = sd
             .serde_info
             .as_ref()
             .and_then(|s| s.parameters.as_ref())
@@ -61,12 +40,34 @@ impl HiveStorageInfo {
             })
             .unwrap_or_default();
 
-        Ok(Self {
-            table_location,
-            input_format,
-            table_schema: TableSchema::new(Arc::new(Schema::new(data_cols)), table_partition_cols),
+        Self::try_new(
+            sd.location.as_deref(),
+            sd.input_format.as_deref(),
+            data_cols,
+            table_partition_cols,
             serde_properties,
-        })
+        )
+    }
+
+    pub fn try_new_from_glue_table(table: &GlueTable) -> Result<Self> {
+        let sd = table.storage_descriptor.as_ref().ok_or_else(|| {
+            DataFusionError::Internal("Storage descriptor not existed".to_string())
+        })?;
+        let data_cols = Self::extract_glue_field_schemas(sd.columns())?;
+        let table_partition_cols = Self::extract_glue_field_schemas(table.partition_keys())?;
+        let serde_properties = sd
+            .serde_info()
+            .and_then(|s| s.parameters())
+            .cloned()
+            .unwrap_or_default();
+
+        Self::try_new(
+            sd.location(),
+            sd.input_format(),
+            data_cols,
+            table_partition_cols,
+            serde_properties,
+        )
     }
 
     pub fn try_get_input_format(input_format: &str) -> Result<HiveInputFormat> {
@@ -84,36 +85,73 @@ impl HiveStorageInfo {
         }
     }
 
-    fn extract_field_schemas(field_schemas: &Option<Vec<FieldSchema>>) -> Result<Vec<Arc<Field>>> {
-        let field_schemas = if let Some(field_schemas) = field_schemas {
-            field_schemas
-        } else {
-            return Ok(Vec::new());
+    fn try_new(
+        table_location: Option<&str>,
+        input_format: Option<&str>,
+        data_cols: Vec<Arc<Field>>,
+        table_partition_cols: Vec<Arc<Field>>,
+        serde_properties: HashMap<String, String>,
+    ) -> Result<Self> {
+        let table_location = table_location
+            .map(ToString::to_string)
+            .ok_or_else(|| DataFusionError::Internal("location not exist".to_string()))?;
+        let input_format = match input_format {
+            Some(input_format) => Self::try_get_input_format(input_format)?,
+            None => {
+                return Err(DataFusionError::Internal(
+                    "input format not existed".to_string(),
+                ));
+            }
         };
+
+        Ok(Self {
+            table_location,
+            input_format,
+            table_schema: TableSchema::new(Arc::new(Schema::new(data_cols)), table_partition_cols),
+            serde_properties,
+        })
+    }
+
+    fn extract_hms_field_schemas(
+        field_schemas: &Option<Vec<FieldSchema>>,
+    ) -> Result<Vec<Arc<Field>>> {
+        let fields: Result<Vec<(String, String)>> = field_schemas
+            .as_ref()
+            .map(|field_schemas| {
+                field_schemas
+                    .iter()
+                    .map(|field_schema| {
+                        let name = field_schema.name.as_ref().ok_or_else(|| {
+                            DataFusionError::Internal("FieldSchema's name not existed".to_string())
+                        })?;
+                        let ty = field_schema.r#type.as_ref().ok_or_else(|| {
+                            DataFusionError::Internal("FieldSchema's type not existed".to_string())
+                        })?;
+                        Ok((name.to_string(), ty.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_else(|| Ok(Vec::new()));
+
+        Self::extract_arrow_fields(fields?)
+    }
+
+    fn extract_glue_field_schemas(field_schemas: &[GlueColumn]) -> Result<Vec<Arc<Field>>> {
         let fields: Result<Vec<(String, String)>> = field_schemas
             .iter()
             .map(|field_schema| {
-                let name: String = match field_schema.name.as_ref() {
-                    Some(s) => s.to_string(),
-                    None => {
-                        return Err(DataFusionError::Internal(
-                            "FieldSchema's name not existed".to_string(),
-                        ));
-                    }
-                };
-                let ty: String = match field_schema.r#type.as_ref() {
-                    Some(s) => s.to_string(),
-                    None => {
-                        return Err(DataFusionError::Internal(
-                            "FieldSchema's type not existed".to_string(),
-                        ));
-                    }
-                };
-                Ok((name, ty))
+                let ty = field_schema.r#type().ok_or_else(|| {
+                    DataFusionError::Internal("FieldSchema's type not existed".to_string())
+                })?;
+                Ok((field_schema.name().to_string(), ty.to_string()))
             })
             .collect();
 
-        let fields: Result<Vec<Arc<Field>>> = fields?
+        Self::extract_arrow_fields(fields?)
+    }
+
+    fn extract_arrow_fields(fields: Vec<(String, String)>) -> Result<Vec<Arc<Field>>> {
+        let fields: Result<Vec<Arc<Field>>> = fields
             .iter()
             .map(|(name, ty)| {
                 Ok(Arc::new(Field::new(


### PR DESCRIPTION
## Summary
- add Hive table loading for Glue catalog tables by reusing the existing Hive table provider path
- extract shared Hive metadata parsing so HMS and Glue use the same storage and partition conversion logic
- preserve metadata table handling for non-Hive Glue tables and allow empty Glue table parameters to fall back to Hive detection

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --verbose`