### PR TITLE
[feat] Support scoped SHOW schemas and tables

### DIFF
--- a/src/app/src/catalog/internal.rs
+++ b/src/app/src/catalog/internal.rs
@@ -45,7 +45,7 @@ impl DobbyDbCatalogProvider for InternalCatalog {
     async fn list_table_names(&self, schema_name: &str) -> Result<Vec<String>> {
         if schema_name != INFORMATION_SCHEMA {
             return Err(DataFusionError::Plan(format!(
-                "{} schema not exist",
+                "schema {} not exist",
                 schema_name
             )));
         }

--- a/src/app/src/catalog/internal.rs
+++ b/src/app/src/catalog/internal.rs
@@ -1,4 +1,4 @@
-use crate::catalog::{CatalogConfig, CatalogManager, DobbyDbCatalogProvider};
+use crate::catalog::DobbyDbCatalogProvider;
 use crate::context::DobbyDbContext;
 use async_trait::async_trait;
 use datafusion::arrow::array::{RecordBatch, StringBuilder};
@@ -15,9 +15,6 @@ use datafusion::physical_plan::streaming::PartitionStream;
 use std::sync::Arc;
 
 pub const INTERNAL_CATALOG: &str = "internal";
-pub const INFORMATION_SCHEMA_SHOW_CATALOGS: &str = "catalogs";
-pub const INFORMATION_SCHEMA_SHOW_SCHEMAS: &str = "schemas";
-pub const INFORMATION_SCHEMA_SHOW_TABLES: &str = "tables";
 pub const INFORMATION_SCHEMA_SHOW_VARIABLES: &str = "variables";
 
 pub fn wrap_with_stream_table(table: Arc<dyn PartitionStream>) -> Result<Arc<StreamingTable>> {
@@ -28,12 +25,14 @@ pub fn wrap_with_stream_table(table: Arc<dyn PartitionStream>) -> Result<Arc<Str
 }
 
 pub struct InternalCatalog {
-    dobbydb_context: Arc<DobbyDbContext>,
+    _dobbydb_context: Arc<DobbyDbContext>,
 }
 
 impl InternalCatalog {
     pub fn new(dobbydb_context: Arc<DobbyDbContext>) -> Self {
-        Self { dobbydb_context }
+        Self {
+            _dobbydb_context: dobbydb_context,
+        }
     }
 }
 
@@ -50,12 +49,7 @@ impl DobbyDbCatalogProvider for InternalCatalog {
                 schema_name
             )));
         }
-        Ok(vec![
-            INFORMATION_SCHEMA_SHOW_CATALOGS.to_string(),
-            INFORMATION_SCHEMA_SHOW_SCHEMAS.to_string(),
-            INFORMATION_SCHEMA_SHOW_TABLES.to_string(),
-            INFORMATION_SCHEMA_SHOW_VARIABLES.to_string(),
-        ])
+        Ok(vec![INFORMATION_SCHEMA_SHOW_VARIABLES.to_string()])
     }
 
     async fn schema_exist(&self, schema_name: &str) -> Result<bool> {
@@ -73,232 +67,25 @@ impl DobbyDbCatalogProvider for InternalCatalog {
 impl AsyncCatalogProvider for InternalCatalog {
     async fn schema(&self, schema_name: &str) -> Result<Option<Arc<dyn AsyncSchemaProvider>>> {
         if schema_name == INFORMATION_SCHEMA {
-            Ok(Some(Arc::new(InformationSchema::new(
-                self.dobbydb_context.catalog_manager.clone(),
-            ))))
+            Ok(Some(Arc::new(InformationSchema)))
         } else {
             Ok(None)
         }
     }
 }
 
-struct InformationSchema {
-    catalog_manager: Arc<CatalogManager>,
-}
-
-impl InformationSchema {
-    pub fn new(catalog_manager: Arc<CatalogManager>) -> Self {
-        Self { catalog_manager }
-    }
-}
+struct InformationSchema;
 
 #[async_trait]
 impl AsyncSchemaProvider for InformationSchema {
     async fn table(&self, table_name: &str) -> Result<Option<Arc<dyn TableProvider>>> {
-        if table_name == INFORMATION_SCHEMA_SHOW_CATALOGS {
-            Ok(Some(wrap_with_stream_table(Arc::new(
-                InformationSchemaShowCatalogs::new(self.catalog_manager.clone()),
-            ))?))
-        } else if table_name == INFORMATION_SCHEMA_SHOW_SCHEMAS {
-            Ok(Some(wrap_with_stream_table(Arc::new(
-                InformationSchemaShowSchemas::new(self.catalog_manager.clone()),
-            ))?))
-        } else if table_name == INFORMATION_SCHEMA_SHOW_TABLES {
-            Ok(Some(wrap_with_stream_table(Arc::new(
-                InformationSchemaShowTables::new(self.catalog_manager.clone()),
-            ))?))
-        } else if table_name == INFORMATION_SCHEMA_SHOW_VARIABLES {
+        if table_name == INFORMATION_SCHEMA_SHOW_VARIABLES {
             Ok(Some(wrap_with_stream_table(Arc::new(
                 InformationSchemaShowVariables::new(),
             ))?))
         } else {
             Ok(None)
         }
-    }
-}
-
-#[derive(Debug)]
-pub struct InformationSchemaShowCatalogs {
-    catalog_manager: Arc<CatalogManager>,
-    schema: SchemaRef,
-}
-
-impl InformationSchemaShowCatalogs {
-    pub fn new(catalog_manager: Arc<CatalogManager>) -> Self {
-        let schema: SchemaRef = Arc::new(Schema::new(vec![
-            Field::new("catalog_name", DataType::Utf8, false),
-            Field::new("catalog_type", DataType::Utf8, false),
-            Field::new("catalog_config", DataType::Utf8, true),
-        ]));
-
-        InformationSchemaShowCatalogs {
-            catalog_manager,
-            schema,
-        }
-    }
-}
-
-impl PartitionStream for InformationSchemaShowCatalogs {
-    fn schema(&self) -> &SchemaRef {
-        &self.schema
-    }
-
-    fn execute(&self, _ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
-        let mut catalog_name_builder = StringBuilder::new();
-        let mut catalog_type_builder = StringBuilder::new();
-        let mut catalog_configs_builder = StringBuilder::new();
-
-        let all_catalogs = self.catalog_manager.list_catalogs();
-        for (catalog_name, catalog_config) in &all_catalogs {
-            catalog_name_builder.append_value(catalog_name);
-            if catalog_name == INTERNAL_CATALOG {
-                catalog_type_builder.append_value("INTERNAL");
-                catalog_configs_builder.append_null();
-                continue;
-            }
-
-            match catalog_config {
-                CatalogConfig::HMS(hms_catalog) => {
-                    catalog_type_builder.append_value("HMS");
-                    catalog_configs_builder.append_value(format!("{:?}", hms_catalog));
-                }
-                CatalogConfig::GLUE(glue_catalog) => {
-                    catalog_type_builder.append_value("GLUE");
-                    catalog_configs_builder.append_value(format!("{:?}", glue_catalog));
-                }
-                CatalogConfig::Internal => {
-                    catalog_type_builder.append_value("INTERNAL");
-                    catalog_configs_builder.append_null();
-                }
-            }
-        }
-        let batch = match RecordBatch::try_new(
-            Arc::clone(&self.schema),
-            vec![
-                Arc::new(catalog_name_builder.finish()),
-                Arc::new(catalog_type_builder.finish()),
-                Arc::new(catalog_configs_builder.finish()),
-            ],
-        ) {
-            Ok(record_batch) => record_batch,
-            Err(error) => {
-                let error = DataFusionError::External(Box::new(error));
-                return Box::pin(RecordBatchStreamAdapter::new(
-                    self.schema.clone(),
-                    futures::stream::once(async move { Err(error) }),
-                ));
-            }
-        };
-
-        Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&self.schema),
-            futures::stream::once(async move { Ok(batch) }),
-        ))
-    }
-}
-
-#[derive(Debug)]
-pub struct InformationSchemaShowSchemas {
-    catalog_manager: Arc<CatalogManager>,
-    schema: SchemaRef,
-}
-
-impl InformationSchemaShowSchemas {
-    pub fn new(catalog_manager: Arc<CatalogManager>) -> Self {
-        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
-            "schema_name",
-            DataType::Utf8,
-            false,
-        )]));
-
-        InformationSchemaShowSchemas {
-            catalog_manager,
-            schema,
-        }
-    }
-}
-
-impl PartitionStream for InformationSchemaShowSchemas {
-    fn schema(&self) -> &SchemaRef {
-        &self.schema
-    }
-
-    fn execute(&self, ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
-        let catalog = &ctx.session_config().options().catalog;
-        let default_catalog = catalog.default_catalog.clone();
-        let catalog_manager = self.catalog_manager.clone();
-        let schema = Arc::clone(&self.schema);
-
-        Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&schema),
-            futures::stream::once(async move {
-                let schema_names = catalog_manager.list_schema_names(&default_catalog).await?;
-                let mut schema_name_builder = StringBuilder::new();
-                for schema_name in schema_names {
-                    schema_name_builder.append_value(schema_name);
-                }
-
-                RecordBatch::try_new(
-                    Arc::clone(&schema),
-                    vec![Arc::new(schema_name_builder.finish())],
-                )
-                .map_err(|error| DataFusionError::External(Box::new(error)))
-            }),
-        ))
-    }
-}
-
-#[derive(Debug)]
-struct InformationSchemaShowTables {
-    catalog_manager: Arc<CatalogManager>,
-    schema: SchemaRef,
-}
-
-impl InformationSchemaShowTables {
-    pub fn new(catalog_manager: Arc<CatalogManager>) -> Self {
-        let schema: SchemaRef = Arc::new(Schema::new(vec![Field::new(
-            "table_name",
-            DataType::Utf8,
-            false,
-        )]));
-
-        InformationSchemaShowTables {
-            catalog_manager,
-            schema,
-        }
-    }
-}
-
-impl PartitionStream for InformationSchemaShowTables {
-    fn schema(&self) -> &SchemaRef {
-        &self.schema
-    }
-
-    fn execute(&self, ctx: Arc<TaskContext>) -> SendableRecordBatchStream {
-        let catalog = &ctx.session_config().options().catalog;
-        let default_catalog = catalog.default_catalog.clone();
-        let default_schema = catalog.default_schema.clone();
-        let catalog_manager = self.catalog_manager.clone();
-        let schema = Arc::clone(&self.schema);
-
-        Box::pin(RecordBatchStreamAdapter::new(
-            Arc::clone(&schema),
-            futures::stream::once(async move {
-                let table_names = catalog_manager
-                    .list_table_names(&default_catalog, &default_schema)
-                    .await?;
-                let mut schema_name_builder = StringBuilder::new();
-                for table_name in table_names {
-                    schema_name_builder.append_value(table_name);
-                }
-
-                RecordBatch::try_new(
-                    Arc::clone(&schema),
-                    vec![Arc::new(schema_name_builder.finish())],
-                )
-                .map_err(|error| DataFusionError::External(Box::new(error)))
-            }),
-        ))
     }
 }
 

--- a/src/app/src/catalog/mod.rs
+++ b/src/app/src/catalog/mod.rs
@@ -6,10 +6,7 @@ pub(crate) mod manager;
 pub(crate) mod table_definition_build;
 pub(crate) mod table_format;
 
-pub(crate) use internal::{
-    INFORMATION_SCHEMA_SHOW_CATALOGS, INFORMATION_SCHEMA_SHOW_SCHEMAS,
-    INFORMATION_SCHEMA_SHOW_TABLES, INFORMATION_SCHEMA_SHOW_VARIABLES, INTERNAL_CATALOG,
-};
+pub(crate) use internal::{INFORMATION_SCHEMA_SHOW_VARIABLES, INTERNAL_CATALOG};
 pub(crate) use manager::{
     CatalogConfig, CatalogConfigs, CatalogManager, DobbyDbCatalogProvider,
     DobbyDbCatalogProviderList,

--- a/src/app/src/server/mod.rs
+++ b/src/app/src/server/mod.rs
@@ -104,8 +104,12 @@ Useful SQL:
   show catalogs;
   show catalogs like '%prod%';
   show schemas;
+  show schemas from <catalog_name>;
+  show schemas from <catalog_name> like '%default%';
   show schemas like '%default%';
   show tables;
+  show tables from <schema_name>;
+  show tables from <catalog_name>.<schema_name> like '%events%';
   show tables like '%events%';
   show variables;
   show variables verbose;

--- a/src/app/src/server/repl.rs
+++ b/src/app/src/server/repl.rs
@@ -12,6 +12,23 @@ use std::fs;
 use std::time::Instant;
 use tokio::signal;
 
+const DOBBYDB_BANNER: &str = concat!(
+    "\x1b[1;38;5;46m██████╗  ██████╗ ██████╗ ██████╗ ██╗   ██╗██████╗ ██████╗ \n",
+    "\x1b[38;5;40m██╔══██╗██╔═══██╗██╔══██╗██╔══██╗╚██╗ ██╔╝██╔══██╗██╔══██╗\n",
+    "\x1b[38;5;34m██║  ██║██║   ██║██████╔╝██████╔╝ ╚████╔╝ ██║  ██║██████╔╝\n",
+    "\x1b[38;5;28m██║  ██║██║   ██║██╔══██╗██╔══██╗  ╚██╔╝  ██║  ██║██╔══██╗\n",
+    "\x1b[38;5;34m██████╔╝╚██████╔╝██████╔╝██████╔╝   ██║   ██████╔╝██████╔╝\n",
+    "\x1b[38;5;40m╚═════╝  ╚═════╝ ╚═════╝ ╚═════╝    ╚═╝   ╚═════╝ ╚═════╝ \n",
+    "\x1b[48;5;16;1;38;5;46m              WAKE UP, QUERY THE DATA LAKE              \x1b[0m"
+);
+
+fn print_banner() {
+    println!("{DOBBYDB_BANNER}");
+    println!(
+        "\x1b[38;5;40m[ CONNECTED ]\x1b[0m Enter SQL ending with ';'. Type 'quit;' to disconnect.\n"
+    );
+}
+
 /// run and execute SQL statements and commands against a context with the given print options
 pub async fn exec_from_repl(ctx: &ExtendedSessionContext, print_options: &PrintOptions) {
     let mut rl = Editor::new().expect("created editor");
@@ -22,8 +39,7 @@ pub async fn exec_from_repl(ctx: &ExtendedSessionContext, print_options: &PrintO
 
     let mut sql_buffer = String::new();
 
-    println!("DobbyDB SQL CLI - Enter your SQL commands (end with ;)");
-    println!("Type 'quit;' to exit\n");
+    print_banner();
 
     loop {
         // 根据是否有未完成的语句选择提示符

--- a/src/app/src/sql/parser.rs
+++ b/src/app/src/sql/parser.rs
@@ -286,7 +286,7 @@ mod tests {
     use crate::statements::{ShowCatalogsStatement, ShowVariablesStatement};
     use sqlparser::ast::{
         Ident, ObjectName, ObjectNamePart, ShowStatementFilter, ShowStatementFilterPosition,
-        ShowStatementOptions, Statement, Use,
+        ShowStatementInClause, ShowStatementOptions, Statement, Use,
     };
 
     #[test]
@@ -367,6 +367,31 @@ mod tests {
     }
 
     #[test]
+    fn test_show_schemas_from_catalog_like() -> Result<()> {
+        let statements = ExtendedParser::parse_sql("show schemas from internal like '%schema%'")?;
+        let SQLStatement(statement) = &statements[0] else {
+            panic!("expected SQL statement");
+        };
+        let Statement::ShowSchemas { show_options, .. } = statement.as_ref() else {
+            panic!("expected SHOW SCHEMAS statement");
+        };
+        let show_in = show_options.show_in.as_ref().expect("expected FROM scope");
+
+        assert_eq!(show_in.clause, ShowStatementInClause::FROM);
+        assert_eq!(
+            show_in.parent_name.as_ref().unwrap().to_string(),
+            "internal"
+        );
+        assert_eq!(
+            show_options.filter_position,
+            Some(ShowStatementFilterPosition::Suffix(
+                ShowStatementFilter::Like("%schema%".to_string())
+            ))
+        );
+        Ok(())
+    }
+
+    #[test]
     fn test_show_tables_like() -> Result<()> {
         let statement = ExtendedParser::parse_sql("show tables like '%foo%'")?;
         let stmt = &statement[0];
@@ -387,6 +412,62 @@ mod tests {
             },
         }));
         assert_eq!(expected_statement, *stmt);
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_tables_from_schema() -> Result<()> {
+        let statements = ExtendedParser::parse_sql("show tables from information_schema")?;
+        let SQLStatement(statement) = &statements[0] else {
+            panic!("expected SQL statement");
+        };
+        let Statement::ShowTables { show_options, .. } = statement.as_ref() else {
+            panic!("expected SHOW TABLES statement");
+        };
+
+        assert_eq!(
+            show_options
+                .show_in
+                .as_ref()
+                .unwrap()
+                .parent_name
+                .as_ref()
+                .unwrap()
+                .to_string(),
+            "information_schema"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_show_tables_from_catalog_schema_like() -> Result<()> {
+        let statements = ExtendedParser::parse_sql(
+            "show tables from internal.information_schema like '%table%'",
+        )?;
+        let SQLStatement(statement) = &statements[0] else {
+            panic!("expected SQL statement");
+        };
+        let Statement::ShowTables { show_options, .. } = statement.as_ref() else {
+            panic!("expected SHOW TABLES statement");
+        };
+
+        assert_eq!(
+            show_options
+                .show_in
+                .as_ref()
+                .unwrap()
+                .parent_name
+                .as_ref()
+                .unwrap()
+                .to_string(),
+            "internal.information_schema"
+        );
+        assert_eq!(
+            show_options.filter_position,
+            Some(ShowStatementFilterPosition::Suffix(
+                ShowStatementFilter::Like("%table%".to_string())
+            ))
+        );
         Ok(())
     }
 

--- a/src/app/src/sql/session.rs
+++ b/src/app/src/sql/session.rs
@@ -832,7 +832,7 @@ mod tests {
             .sql("show tables from missing_schema")
             .await
             .unwrap_err();
-        assert_contains!(error.to_string(), "unknown schema internal.missing_schema");
+        assert_contains!(error.to_string(), "schema missing_schema not exist");
 
         let error = session
             .sql("show tables from internal.information_schema.extra")

--- a/src/app/src/sql/session.rs
+++ b/src/app/src/sql/session.rs
@@ -287,16 +287,6 @@ impl ExtendedSessionContext {
         let catalog_name = Self::resolve_show_scope(show_options, "SHOW SCHEMAS", 1)?
             .map_or_else(|| default_catalog, |parts| parts[0].clone());
 
-        if !self
-            .dobbydb_context
-            .catalog_manager
-            .catalog_exists(&catalog_name)
-        {
-            return Err(DataFusionError::Plan(format!(
-                "unknown catalog {catalog_name}"
-            )));
-        }
-
         let schema_names = self
             .dobbydb_context
             .catalog_manager
@@ -320,26 +310,6 @@ impl ExtendedSessionContext {
                 Some(parts) if parts.len() == 1 => (default_catalog, parts[0].clone()),
                 Some(parts) => (parts[0].clone(), parts[1].clone()),
             };
-
-        if !self
-            .dobbydb_context
-            .catalog_manager
-            .catalog_exists(&catalog_name)
-        {
-            return Err(DataFusionError::Plan(format!(
-                "unknown catalog {catalog_name}"
-            )));
-        }
-        if !self
-            .dobbydb_context
-            .catalog_manager
-            .schema_exist(&catalog_name, &schema_name)
-            .await?
-        {
-            return Err(DataFusionError::Plan(format!(
-                "unknown schema {catalog_name}.{schema_name}"
-            )));
-        }
 
         let table_names = self
             .dobbydb_context

--- a/src/app/src/sql/session.rs
+++ b/src/app/src/sql/session.rs
@@ -1,7 +1,6 @@
 use crate::catalog::{
-    CatalogManager, DobbyDbCatalogProviderList, INFORMATION_SCHEMA_SHOW_CATALOGS,
-    INFORMATION_SCHEMA_SHOW_SCHEMAS, INFORMATION_SCHEMA_SHOW_TABLES,
-    INFORMATION_SCHEMA_SHOW_VARIABLES, INTERNAL_CATALOG,
+    CatalogConfig, CatalogManager, DobbyDbCatalogProviderList, INFORMATION_SCHEMA_SHOW_VARIABLES,
+    INTERNAL_CATALOG,
 };
 use crate::context::DobbyDbContext;
 use crate::parser::ExtendedParser;
@@ -19,10 +18,10 @@ use datafusion::execution::TaskContext;
 use datafusion::execution::runtime_env::RuntimeEnv;
 use datafusion::logical_expr::sqlparser::ast::{
     ObjectName, ObjectNamePart, ShowCreateObject, ShowStatementFilter, ShowStatementFilterPosition,
-    ShowStatementOptions, Statement, Use,
+    ShowStatementInParentType, ShowStatementOptions, Statement, Use,
 };
 use datafusion::logical_expr::{ExplainFormat, LogicalPlanBuilder};
-use datafusion::prelude::{SessionConfig, SessionContext};
+use datafusion::prelude::{SessionConfig, SessionContext, col, lit};
 use datafusion::sql::parser::Statement as DataFusionStatement;
 use dobbydb_common::runtime::RuntimeManager;
 use std::collections::HashMap;
@@ -124,7 +123,7 @@ impl ExtendedSessionContext {
     pub async fn create_dataframe(&self, statement: &ExtendedStatement) -> Result<DataFrame> {
         let sql_string: String = match statement {
             ExtendedStatement::ShowCatalogsStatement(show_catalogs) => {
-                self.build_show_catalogs_sql(show_catalogs)?
+                return self.handle_show_catalogs(show_catalogs);
             }
             ExtendedStatement::ShowVariablesStatement(show_variables) => {
                 self.build_show_variables_sql(&show_variables.filter, show_variables.verbose)?
@@ -134,10 +133,10 @@ impl ExtendedSessionContext {
                     return self.handle_use_stmt(use_stmt).await;
                 }
                 Statement::ShowSchemas { show_options, .. } => {
-                    self.build_show_schemas_sql(show_options)?
+                    return self.handle_show_schemas(show_options).await;
                 }
                 Statement::ShowTables { show_options, .. } => {
-                    self.build_show_tables_sql(show_options)?
+                    return self.handle_show_tables(show_options).await;
                 }
                 _ => stmt.to_string(),
             },
@@ -218,30 +217,6 @@ impl ExtendedSessionContext {
         Ok(format!("{base_sql} ORDER BY NAME"))
     }
 
-    fn build_show_catalogs_sql(&self, show_catalogs: &ShowCatalogsStatement) -> Result<String> {
-        self.build_filtered_virtual_table_sql(
-            INFORMATION_SCHEMA_SHOW_CATALOGS,
-            "catalog_name",
-            &show_catalogs.filter,
-        )
-    }
-
-    fn build_show_schemas_sql(&self, show_options: &ShowStatementOptions) -> Result<String> {
-        self.build_filtered_virtual_table_sql(
-            INFORMATION_SCHEMA_SHOW_SCHEMAS,
-            "schema_name",
-            &Self::show_like_filter(show_options),
-        )
-    }
-
-    fn build_show_tables_sql(&self, show_options: &ShowStatementOptions) -> Result<String> {
-        self.build_filtered_virtual_table_sql(
-            INFORMATION_SCHEMA_SHOW_TABLES,
-            "table_name",
-            &Self::show_like_filter(show_options),
-        )
-    }
-
     fn show_like_filter(show_options: &ShowStatementOptions) -> Option<ShowStatementFilter> {
         match &show_options.filter_position {
             None => None,
@@ -255,29 +230,190 @@ impl ExtendedSessionContext {
         }
     }
 
-    fn build_filtered_virtual_table_sql(
-        &self,
-        table_name: &str,
-        column_name: &str,
-        filter: &Option<ShowStatementFilter>,
-    ) -> Result<String> {
-        let base_sql = format!(
-            "SELECT * FROM {}.{}.{}",
-            INTERNAL_CATALOG, INFORMATION_SCHEMA, table_name
-        );
+    fn handle_show_catalogs(&self, show_catalogs: &ShowCatalogsStatement) -> Result<DataFrame> {
+        let catalogs = self.dobbydb_context.catalog_manager.list_catalogs();
+        let mut catalog_names = Vec::with_capacity(catalogs.len());
+        let mut catalog_types = Vec::with_capacity(catalogs.len());
+        let mut catalog_configs = Vec::with_capacity(catalogs.len());
 
-        let base_sql = match filter {
-            None => base_sql,
-            Some(ShowStatementFilter::Like(pattern)) => {
-                format!(
-                    "{base_sql} WHERE {column_name} LIKE '{}'",
-                    Self::escape_sql_string(pattern)
-                )
+        for (catalog_name, catalog_config) in catalogs {
+            catalog_names.push(catalog_name);
+            match catalog_config {
+                CatalogConfig::Internal => {
+                    catalog_types.push("INTERNAL".to_string());
+                    catalog_configs.push(None);
+                }
+                CatalogConfig::HMS(config) => {
+                    catalog_types.push("HMS".to_string());
+                    catalog_configs.push(Some(format!("{config:?}")));
+                }
+                CatalogConfig::GLUE(config) => {
+                    catalog_types.push("GLUE".to_string());
+                    catalog_configs.push(Some(format!("{config:?}")));
+                }
             }
-            _ => base_sql,
-        };
+        }
 
-        Ok(format!("{base_sql} ORDER BY {column_name}"))
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("catalog_name", DataType::Utf8, false),
+            Field::new("catalog_type", DataType::Utf8, false),
+            Field::new("catalog_config", DataType::Utf8, true),
+        ]));
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(catalog_names)),
+                Arc::new(StringArray::from(catalog_types)),
+                Arc::new(StringArray::from(catalog_configs)),
+            ],
+        )
+        .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let mut dataframe = self.session_context.read_batch(batch)?;
+        if let Some(ShowStatementFilter::Like(pattern)) = &show_catalogs.filter {
+            dataframe = dataframe.filter(col("catalog_name").like(lit(pattern.clone())))?;
+        }
+        dataframe.sort(vec![col("catalog_name").sort(true, false)])
+    }
+
+    async fn handle_show_schemas(&self, show_options: &ShowStatementOptions) -> Result<DataFrame> {
+        let default_catalog = self
+            .session_context
+            .state()
+            .config()
+            .options()
+            .catalog
+            .default_catalog
+            .clone();
+        let catalog_name = Self::resolve_show_scope(show_options, "SHOW SCHEMAS", 1)?
+            .map_or_else(|| default_catalog, |parts| parts[0].clone());
+
+        if !self
+            .dobbydb_context
+            .catalog_manager
+            .catalog_exists(&catalog_name)
+        {
+            return Err(DataFusionError::Plan(format!(
+                "unknown catalog {catalog_name}"
+            )));
+        }
+
+        let schema_names = self
+            .dobbydb_context
+            .catalog_manager
+            .list_schema_names(&catalog_name)
+            .await?;
+        self.build_show_names_dataframe(
+            "schema_name",
+            schema_names,
+            Self::show_like_filter(show_options),
+        )
+    }
+
+    async fn handle_show_tables(&self, show_options: &ShowStatementOptions) -> Result<DataFrame> {
+        let state = self.session_context.state();
+        let catalog_options = &state.config().options().catalog;
+        let default_catalog = catalog_options.default_catalog.clone();
+        let default_schema = catalog_options.default_schema.clone();
+        let (catalog_name, schema_name) =
+            match Self::resolve_show_scope(show_options, "SHOW TABLES", 2)? {
+                None => (default_catalog, default_schema),
+                Some(parts) if parts.len() == 1 => (default_catalog, parts[0].clone()),
+                Some(parts) => (parts[0].clone(), parts[1].clone()),
+            };
+
+        if !self
+            .dobbydb_context
+            .catalog_manager
+            .catalog_exists(&catalog_name)
+        {
+            return Err(DataFusionError::Plan(format!(
+                "unknown catalog {catalog_name}"
+            )));
+        }
+        if !self
+            .dobbydb_context
+            .catalog_manager
+            .schema_exist(&catalog_name, &schema_name)
+            .await?
+        {
+            return Err(DataFusionError::Plan(format!(
+                "unknown schema {catalog_name}.{schema_name}"
+            )));
+        }
+
+        let table_names = self
+            .dobbydb_context
+            .catalog_manager
+            .list_table_names(&catalog_name, &schema_name)
+            .await?;
+        self.build_show_names_dataframe(
+            "table_name",
+            table_names,
+            Self::show_like_filter(show_options),
+        )
+    }
+
+    fn resolve_show_scope(
+        show_options: &ShowStatementOptions,
+        statement_name: &str,
+        max_parts: usize,
+    ) -> Result<Option<Vec<String>>> {
+        let Some(show_in) = &show_options.show_in else {
+            return Ok(None);
+        };
+        if show_in.parent_type.as_ref().is_some_and(|parent_type| {
+            !matches!(
+                parent_type,
+                ShowStatementInParentType::Database | ShowStatementInParentType::Schema
+            )
+        }) {
+            return Err(DataFusionError::Plan(format!(
+                "{statement_name} does not support {} scope",
+                show_in.parent_type.as_ref().unwrap()
+            )));
+        }
+        let parent_name = show_in.parent_name.as_ref().ok_or_else(|| {
+            DataFusionError::Plan(format!("{statement_name} requires a scope name"))
+        })?;
+        let parts = parent_name
+            .0
+            .iter()
+            .map(Self::convert_object_name_part_to_string)
+            .collect::<Result<Vec<_>>>()?;
+        if parts.is_empty() || parts.len() > max_parts {
+            return Err(DataFusionError::Plan(format!(
+                "{statement_name} supports at most {max_parts} scope name part(s)"
+            )));
+        }
+        Ok(Some(parts))
+    }
+
+    fn convert_object_name_part_to_string(part: &ObjectNamePart) -> Result<String> {
+        part.as_ident()
+            .map(|ident| ident.value.clone())
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!("unsupported SHOW scope name part: {part}"))
+            })
+    }
+
+    fn build_show_names_dataframe(
+        &self,
+        column_name: &str,
+        names: Vec<String>,
+        filter: Option<ShowStatementFilter>,
+    ) -> Result<DataFrame> {
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            column_name,
+            DataType::Utf8,
+            false,
+        )]));
+        let batch = RecordBatch::try_new(schema, vec![Arc::new(StringArray::from(names))])
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
+        let mut dataframe = self.session_context.read_batch(batch)?;
+        if let Some(ShowStatementFilter::Like(pattern)) = filter {
+            dataframe = dataframe.filter(col(column_name).like(lit(pattern)))?;
+        }
+        dataframe.sort(vec![col(column_name).sort(true, false)])
     }
 
     fn escape_sql_string(value: &str) -> String {
@@ -626,16 +762,113 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_show_tables_like_execution() -> Result<()> {
+    async fn test_show_schemas_from_catalog_like_execution() -> Result<()> {
         let session = ExtendedSessionContext::default();
         let batches = session
-            .sql("show tables like '%table%'")
+            .sql("show schemas from internal like 'information_schem_'")
             .await?
             .collect()
             .await?;
         let output = pretty_format_batches(&batches)?.to_string();
-        assert_contains!(output.as_str(), "tables");
+
+        assert_contains!(output.as_str(), "information_schema");
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_tables_like_execution() -> Result<()> {
+        let session = ExtendedSessionContext::default();
+        let batches = session
+            .sql("show tables like '%variable%'")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+        assert_contains!(output.as_str(), "variables");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_tables_from_schema_execution() -> Result<()> {
+        let session = ExtendedSessionContext::default();
+        let batches = session
+            .sql("show tables from information_schema")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_contains!(output.as_str(), "variables");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_tables_from_catalog_schema_like_execution() -> Result<()> {
+        let session = ExtendedSessionContext::default();
+        let batches = session
+            .sql("show tables from internal.information_schema like '%variable%'")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_contains!(output.as_str(), "variables");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_tables_from_internal_information_schema_no_catalog_virtual_tables()
+    -> Result<()> {
+        let session = ExtendedSessionContext::default();
+        let batches = session
+            .sql("show tables from internal.information_schema")
+            .await?
+            .collect()
+            .await?;
+        let output = pretty_format_batches(&batches)?.to_string();
+
+        assert_contains!(output.as_str(), "variables");
+        assert!(!output.contains("catalogs"));
+        assert!(!output.contains("schemas"));
+        assert!(!output.contains("tables"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_internal_information_schema_variables_execution() -> Result<()> {
+        let session = ExtendedSessionContext::default();
+        let batches = session
+            .sql("select name, value from internal.information_schema.variables limit 1")
+            .await?
+            .collect()
+            .await?;
+
+        assert_eq!(batches[0].schema().field(0).name(), "name");
+        assert_eq!(batches[0].schema().field(1).name(), "value");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_show_scope_errors() {
+        let session = ExtendedSessionContext::default();
+
+        let error = session
+            .sql("show schemas from missing_catalog")
+            .await
+            .unwrap_err();
+        assert_contains!(error.to_string(), "unknown catalog missing_catalog");
+
+        let error = session
+            .sql("show tables from missing_schema")
+            .await
+            .unwrap_err();
+        assert_contains!(error.to_string(), "unknown schema internal.missing_schema");
+
+        let error = session
+            .sql("show tables from internal.information_schema.extra")
+            .await
+            .unwrap_err();
+        assert_contains!(error.to_string(), "supports at most 2 scope name part(s)");
     }
 
     #[test]
@@ -732,10 +965,9 @@ mod tests {
     #[test]
     fn test_show_like_sql_escapes_quotes() -> Result<()> {
         let session = ExtendedSessionContext::default();
-        let sql = session.build_filtered_virtual_table_sql(
-            INFORMATION_SCHEMA_SHOW_CATALOGS,
-            "catalog_name",
+        let sql = session.build_show_variables_sql(
             &Some(ShowStatementFilter::Like("%o''hara%".to_string())),
+            false,
         )?;
 
         assert_contains!(sql.as_str(), "LIKE '%o''''hara%'");


### PR DESCRIPTION
## Summary
- support catalog-scoped `SHOW SCHEMAS` and schema-scoped `SHOW TABLES`, including `LIKE` filters
- simplify internal information schema handling
- display the DobbyDB logo in the REPL

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-targets --all-features --verbose`